### PR TITLE
Fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ $entityManager->flush();
 
 ```php
 <?php
-// untested, i have not tested composite id's
-$response = $entityManager->find("Response",array("1234","kontakt@beberlei.de"));
+$response = $entityManager->find("Response",array("campaign" => "1234","recipient" => "kontakt@beberlei.de"));
 ```
 
 ### Update
@@ -107,6 +106,8 @@ Cache backend:
 use Doctrine\KeyValueStore\EntityManager;
 use Doctrine\KeyValueStore\Mapping\AnnotationDriver;
 use Doctrine\KeyValueStore\Storage\DoctrineCacheStorage;
+use Doctrine\KeyValueStore\Configuration;
+use Doctrine\KeyValueStore\EntityManager;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Annotations\AnnotationReader;
 


### PR DESCRIPTION
The current example requires two additional use statements to be functional with a copy-paste.  Additionally the composite key does not work as provided, it requires the key field names to be specified to function.

Not sure what @beberlei thinks about including in the example loading of the AnnotationRegistry?  If this is done the example is a straight drop in and will work out of the box.  If that's something you want added let me know. 
