### PR TITLE
Initial AWS SimpleDB storage implementation

### DIFF
--- a/lib/Doctrine/KeyValueStore/Storage/SimpleDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/SimpleDbStorage.php
@@ -48,24 +48,6 @@ class SimpleDbStorage implements Storage
     }
 
     /**
-     * @param string $tableName
-     */
-    protected function createDomain($domainName)
-    {
-        try {
-            $domain = $this->client->domainMetadata(array('DomainName' => $domainName));
-        } catch (NoSuchDomainException $e) {
-            $this->client->createDomain(array('DomainName' => $domainName));
-    
-            $domain = $this->client->domainMetadata(array('DomainName' => $domainName));
-        } catch (SimpleDbException $e) {
-            throw new KeyValueStoreException($e->getMessage(), 0, $e);
-        }
-        
-        return $domain;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function supportsPartialUpdates()
@@ -87,27 +69,6 @@ class SimpleDbStorage implements Storage
     public function requiresCompositePrimaryKeys()
     {
         return false;
-    }
-
-    /**
-     * @param string $key 
-     * @param array $data 
-     */
-    protected function makeAttributes($data)
-    {
-        $attributes = array();
-
-        foreach ($data as $name => $value) {
-            if ($value !== null && $value !== array() && $value !== '') {
-                $attributes[] = array(
-                    'Name' => $name,
-                    'Value' => $value,
-                    'Replace' => true,
-                );
-            }
-        }
-        
-        return $attributes;
     }
 
     /**
@@ -179,5 +140,44 @@ class SimpleDbStorage implements Storage
     public function getName()
     {
         return 'simpledb';
+    }
+
+    /**
+     * @param string $tableName
+     */
+    protected function createDomain($domainName)
+    {
+        try {
+            $domain = $this->client->domainMetadata(array('DomainName' => $domainName));
+        } catch (NoSuchDomainException $e) {
+            $this->client->createDomain(array('DomainName' => $domainName));
+
+            $domain = $this->client->domainMetadata(array('DomainName' => $domainName));
+        } catch (SimpleDbException $e) {
+            throw new KeyValueStoreException($e->getMessage(), 0, $e);
+        }
+
+        return $domain;
+    }
+
+    /**
+     * @param string $key 
+     * @param array $data 
+     */
+    protected function makeAttributes($data)
+    {
+        $attributes = array();
+
+        foreach ($data as $name => $value) {
+            if ($value !== null && $value !== array() && $value !== '') {
+                $attributes[] = array(
+                    'Name' => $name,
+                    'Value' => $value,
+                    'Replace' => true,
+                );
+            }
+        }
+
+        return $attributes;
     }
 }


### PR DESCRIPTION
This implementation does involve composite keys. If there is interest I think I can add that in, as that's a big reason to be using SimpleDb over DynamoDb anyhow. I also need suggestion on best practices for escaping the field data in the SelectExpression.
