### PR TITLE
The Doctrine\KeyValueStore\EntityManager class is imported twice in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ use Doctrine\KeyValueStore\EntityManager;
 use Doctrine\KeyValueStore\Mapping\AnnotationDriver;
 use Doctrine\KeyValueStore\Storage\DoctrineCacheStorage;
 use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\EntityManager;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Annotations\AnnotationReader;
 


### PR DESCRIPTION
Not a big deal, but the `Doctrine\KeyValueStore\EntityManager` is imported twice in the example code. Therefore copy-and-pasting as-is will result in a fatal error.

Thanks!
Chris
