### PR TITLE
Add missing field for class metadata serialization (needed when using redis cache)

### DIFF
--- a/lib/Doctrine/KeyValueStore/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/ClassMetadata.php
@@ -75,7 +75,7 @@ class ClassMetadata implements BaseClassMetadata
 
     public function __sleep()
     {
-        return array('fields', 'isCompositeKey', 'identifier', 'name');
+        return array('fields', 'isCompositeKey', 'identifier', 'name', 'storageName');
     }
 
     public function getIdentifierValues($object)


### PR DESCRIPTION
Original problem occurred with the following constellation:
```php
<?php
use Doctrine\KeyValueStore\EntityManager;
use Doctrine\KeyValueStore\Configuration;
use Doctrine\KeyValueStore\Mapping\AnnotationDriver;
use Doctrine\KeyValueStore\Storage\DoctrineCacheStorage;
use Doctrine\Common\Cache\RedisCache;
use Doctrine\Common\Annotations\AnnotationReader;

$cache = new RedisCache();
$redis = new \Redis();
$redis->connect('localhost');
$cache->setRedis($redis);
$storage = new DoctrineCacheStorage($cache);

$reader = new AnnotationReader();
$metadata = new AnnotationDriver($reader);
$config = new Configuration();
$config->setMappingDriverImpl($metadata);
$config->setMetadataCache($cache);

$entityManager = new EntityManager($storage, $config);

// persisting for the first time OK
$product = new Product(); // entity with proper KV annotations (especially 'storageName')
$em->persist($product);
$em->flush(); // produces correct redis key, e.g. '[product-oid:id=123;][1]'
$product->addPrice(3.99);
// persisting next time not OK
$em->persist($product);
$em->flush(); // produces wrong redis key (storageName missing), e.g. '[-oid:id=123;][1]'
