### PR TITLE
Fix @Transient annotation -- logic bug plus broken due to typo

### DIFF
--- a/lib/Doctrine/KeyValueStore/Mapping/AnnotationDriver.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/AnnotationDriver.php
@@ -59,7 +59,7 @@ class AnnotationDriver implements MappingDriver
             if ($idAnnot) {
                 $metadata->mapIdentifier($property->getName());
             } else if ($transientAnnot) {
-                $metdata->skipTransientField($property->getName());
+                $metadata->skipTransientField($property->getName());
             } else {
                 $metadata->mapField(array('fieldName' => $property->getName()));
             }

--- a/lib/Doctrine/KeyValueStore/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/ClassMetadata.php
@@ -56,6 +56,9 @@ class ClassMetadata implements BaseClassMetadata
 
     public function skipTransientField($fieldName)
     {
+        // it's necessary to unset because ClassMetadataFactory::initializeReflection has already run
+        // and the fields have all been mapped -- even the transient ones
+        unset($this->fields[$fieldName]);
         $this->transientFields[$fieldName] = true;
     }
 


### PR DESCRIPTION
The `@Transient` annotation simply does not work because

1. trying to use it dies with trying method call on non-object (due to typo)
2. there's a logic bug causing the annotation to close the barn door after the horse is gone

This PR fixes both issues.