### PR TITLE
Yaml driver

### DIFF
--- a/lib/Doctrine/KeyValueStore/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/Driver/AnnotationDriver.php
@@ -17,16 +17,27 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore\Mapping;
+namespace Doctrine\KeyValueStore\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 
 class AnnotationDriver implements MappingDriver
 {
+    /**
+     * Doctrine common annotations reader.
+     *
+     * @var AnnotationReader
+     */
     private $reader;
 
-    public function __construct($reader)
+    /**
+     * Constructor with required dependencies.
+     *
+     * @param $reader AnnotationReader Doctrine common annotations reader.
+     */
+    public function __construct(AnnotationReader $reader)
     {
         $this->reader = $reader;
     }
@@ -46,7 +57,7 @@ class AnnotationDriver implements MappingDriver
             $class = new \ReflectionClass($metadata->name);
         }
 
-        $entityAnnot = $this->reader->getClassAnnotation($class, 'Doctrine\KeyValueStore\Mapping\Annotations\Entity');
+        $entityAnnot = $this->reader->getClassAnnotation($class, 'Doctrine\KeyValueStore\Mapping\Entity');
         if (!$entityAnnot) {
             throw new \InvalidArgumentException($metadata->name . " is not a valid key-value-store entity.");
         }
@@ -56,11 +67,11 @@ class AnnotationDriver implements MappingDriver
         foreach ($class->getProperties() as $property) {
             $idAnnot        = $this->reader->getPropertyAnnotation(
                 $property,
-                'Doctrine\KeyValueStore\Mapping\Annotations\Id'
+                'Doctrine\KeyValueStore\Mapping\Id'
             );
             $transientAnnot = $this->reader->getPropertyAnnotation(
                 $property,
-                'Doctrine\KeyValueStore\Mapping\Annotations\Transient'
+                'Doctrine\KeyValueStore\Mapping\Transient'
             );
             if ($idAnnot) {
                 $metadata->mapIdentifier($property->getName());

--- a/lib/Doctrine/KeyValueStore/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/Driver/YamlDriver.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore\Mapping\Driver;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
+use Doctrine\Common\Persistence\Mapping\MappingException;
+use Symfony\Component\Yaml\Yaml;
+
+class YamlDriver extends FileDriver
+{
+    const DEFAULT_FILE_EXTENSION = '.dcm.yml';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct($locator, $fileExtension = self::DEFAULT_FILE_EXTENSION)
+    {
+        parent::__construct($locator, $fileExtension);
+    }
+
+    /**
+     * Loads a mapping file with the given name and returns a map
+     * from class/entity names to their corresponding file driver elements.
+     *
+     * @param string $file The mapping file to load.
+     *
+     * @return array
+     */
+    protected function loadMappingFile($file)
+    {
+        return Yaml::parse(file_get_contents($file));
+    }
+
+    /**
+     * Loads the metadata for the specified class into the provided container.
+     *
+     * @param string $className
+     * @param ClassMetadata $metadata
+     *
+     * @return void
+     */
+    public function loadMetadataForClass($className, ClassMetadata $metadata)
+    {
+        /** @var \Doctrine\KeyValueStore\Mapping\ClassMetadata $metadata */
+        try {
+            $element = $this->getElement($className);
+        } catch (MappingException $exception) {
+            throw new \InvalidArgumentException($metadata->name . ' is not a valid key-value-store entity.');
+        }
+
+        $class = new \ReflectionClass($className);
+
+        if (isset($element['storageName'])) {
+            $metadata->storageName = $element['storageName'];
+        }
+
+        $ids = [];
+        if (isset($element['id'])) {
+            $ids = $element['id'];
+        }
+
+        $transients = [];
+        if (isset($element['transient'])) {
+            $transients = $element['transient'];
+        }
+
+        foreach ($class->getProperties() as $property) {
+            if (in_array($property->getName(), $ids)) {
+                $metadata->mapIdentifier($property->getName());
+
+                continue;
+            }
+
+            if (in_array($property->getName(), $transients)) {
+                $metadata->skipTransientField($property->getName());
+
+                continue;
+            }
+
+            $metadata->mapField(array(
+                'fieldName' => $property->getName(),
+            ));
+        }
+    }
+}

--- a/lib/Doctrine/KeyValueStore/Mapping/Entity.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/Entity.php
@@ -17,11 +17,16 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore\Mapping\Annotations;
+namespace Doctrine\KeyValueStore\Mapping;
 
 /**
  * @Annotation
+ * @Target("CLASS")
  */
-class Transient
+final class Entity
 {
+    /**
+     * @var string
+     */
+    public $storageName;
 }

--- a/lib/Doctrine/KeyValueStore/Mapping/Id.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/Id.php
@@ -17,15 +17,12 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore\Mapping\Annotations;
+namespace Doctrine\KeyValueStore\Mapping;
 
 /**
  * @Annotation
+ * @Target("PROPERTY")
  */
-class Entity
+final class Id
 {
-    /**
-     * @var string
-     */
-    public $storageName;
 }

--- a/lib/Doctrine/KeyValueStore/Mapping/Transient.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/Transient.php
@@ -17,11 +17,12 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore\Mapping\Annotations;
+namespace Doctrine\KeyValueStore\Mapping;
 
 /**
  * @Annotation
+ * @Target("PROPERTY")
  */
-class Id
+final class Transient
 {
 }

--- a/tests/Doctrine/Tests/KeyValueStore/Functional/BasicCrudTestCase.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Functional/BasicCrudTestCase.php
@@ -30,7 +30,6 @@ abstract class BasicCrudTestCase extends KeyValueStoreTestCase
     public function setUp()
     {
         $this->storage = $this->createStorage();
-        $this->manager = $this->createManager($this->storage);
     }
 
     abstract protected function createStorage();
@@ -41,8 +40,13 @@ abstract class BasicCrudTestCase extends KeyValueStoreTestCase
 
     abstract protected function find($id);
 
-    public function testPersistItem()
+    /**
+     * @dataProvider mappingDrivers
+     */
+    public function testPersistItem($mappingDriver)
     {
+        $this->manager = $this->createManager($this->storage, $mappingDriver);
+
         $post = new Post();
         $post->id = "1";
         $post->headline = "asdf";
@@ -54,8 +58,13 @@ abstract class BasicCrudTestCase extends KeyValueStoreTestCase
         $this->assertKeyExists($post->id);
     }
 
-    public function testPersistAndRetrieveItem()
+    /**
+     * @dataProvider mappingDrivers
+     */
+    public function testPersistAndRetrieveItem($mappingDriver)
     {
+        $this->manager = $this->createManager($this->storage, $mappingDriver);
+
         $post = new Post();
         $post->id = "1";
         $post->headline = "asdf";
@@ -68,8 +77,13 @@ abstract class BasicCrudTestCase extends KeyValueStoreTestCase
         $this->assertSame($post, $post2);
     }
 
-    public function testRetrieveItem()
+    /**
+     * @dataProvider mappingDrivers
+     */
+    public function testRetrieveItem($mappingDriver)
     {
+        $this->manager = $this->createManager($this->storage, $mappingDriver);
+
         $this->populate(1, array('id' => 1, 'headline' => 'test', 'body' => 'tset', 'foo' => 'bar', 'php_class' => __NAMESPACE__ . '\\Post'));
 
         $post = $this->manager->find(__NAMESPACE__ . '\\Post', 1);
@@ -82,8 +96,13 @@ abstract class BasicCrudTestCase extends KeyValueStoreTestCase
         $this->assertSame($post, $post2);
     }
 
-    public function testUpdateClass()
+    /**
+     * @dataProvider mappingDrivers
+     */
+    public function testUpdateClass($mappingDriver)
     {
+        $this->manager = $this->createManager($this->storage, $mappingDriver);
+
         $post = new Post();
         $post->id = "1";
         $post->headline = "asdf";
@@ -109,8 +128,13 @@ abstract class BasicCrudTestCase extends KeyValueStoreTestCase
         );
     }
 
-    public function testRemoveClass()
+    /**
+     * @dataProvider mappingDrivers
+     */
+    public function testRemoveClass($mappingDriver)
     {
+        $this->manager = $this->createManager($this->storage, $mappingDriver);
+
         $post = new Post();
         $post->id = "1";
         $post->headline = "asdf";
@@ -125,6 +149,14 @@ abstract class BasicCrudTestCase extends KeyValueStoreTestCase
         $this->manager->flush();
 
         $this->assertKeyNotExists($post->id);
+    }
+
+    public function mappingDrivers()
+    {
+        return [
+            ['annotation'],
+            ['yaml'],
+        ];
     }
 }
 

--- a/tests/Doctrine/Tests/KeyValueStore/Functional/BasicCrudTestCase.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Functional/BasicCrudTestCase.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\Tests\KeyValueStore\Functional;
 
-use Doctrine\KeyValueStore\Mapping\Annotations as KVS;
+use Doctrine\KeyValueStore\Mapping as KVS;
 use Doctrine\Tests\KeyValueStoreTestCase;
 
 abstract class BasicCrudTestCase extends KeyValueStoreTestCase

--- a/tests/Doctrine/Tests/KeyValueStore/Functional/InheritanceTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Functional/InheritanceTest.php
@@ -11,15 +11,15 @@ class InheritanceTest extends KeyValueStoreTestCase
     private $manager;
     protected $storage;
 
-    public function setUp()
+    /**
+     * @dataProvider mappingDrivers
+     */
+    public function testInheritance($mappingDriver)
     {
         $cache = new ArrayCache();
         $storage = new DoctrineCacheStorage($cache);
-        $this->manager = $this->createManager($storage);
-    }
+        $this->manager = $this->createManager($storage, $mappingDriver);
 
-    public function testInheritance()
-    {
         $parent = new ParentEntity;
         $parent->id = 1;
         $parent->foo = "foo";
@@ -44,6 +44,14 @@ class InheritanceTest extends KeyValueStoreTestCase
         $this->assertEquals(2, $child->id);
         $this->assertEquals('bar', $child->foo);
         $this->assertEquals('baz', $child->bar);
+    }
+
+    public function mappingDrivers()
+    {
+        return [
+            ['annotation'],
+            ['yaml'],
+        ];
     }
 }
 

--- a/tests/Doctrine/Tests/KeyValueStore/Functional/InheritanceTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Functional/InheritanceTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\Tests\KeyValueStore\Functional;
 
-use Doctrine\KeyValueStore\Mapping\Annotations as KVS;
+use Doctrine\KeyValueStore\Mapping as KVS;
 use Doctrine\KeyValueStore\Storage\DoctrineCacheStorage;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Tests\KeyValueStoreTestCase;

--- a/tests/Doctrine/Tests/KeyValueStore/Functional/PersistTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Functional/PersistTest.php
@@ -24,26 +24,35 @@ use Doctrine\KeyValueStore\Mapping as KVS;
 
 class PersistTest extends KeyValueStoreTestCase
 {
-    public function testPersistUnmappedThrowsException()
+    /**
+     * @dataProvider mappingDrivers
+     */
+    public function testPersistUnmappedThrowsException($mappingDriver)
     {
-        $manager = $this->createManager();
+        $manager = $this->createManager(null, $mappingDriver);
 
         $this->setExpectedException('InvalidArgumentException', 'stdClass is not a valid key-value-store entity.');
         $manager->persist(new \stdClass());
     }
 
-    public function testPersistWithoutIdThrowsException()
+    /**
+     * @dataProvider mappingDrivers
+     */
+    public function testPersistWithoutIdThrowsException($mappingDriver)
     {
-        $manager = $this->createManager();
+        $manager = $this->createManager(null, $mappingDriver);
         $persist = new PersistEntity();
 
         $this->setExpectedException('RuntimeException', 'Trying to persist entity that has no id.');
         $manager->persist($persist);
     }
 
-    public function testPersistKnownIdThrowsException()
+    /**
+     * @dataProvider mappingDrivers
+     */
+    public function testPersistKnownIdThrowsException($mappingDriver)
     {
-        $manager = $this->createManager();
+        $manager = $this->createManager(null, $mappingDriver);
         $persist = new PersistEntity();
         $persist->id = 1;
 
@@ -54,6 +63,14 @@ class PersistTest extends KeyValueStoreTestCase
 
         $this->setExpectedException('RuntimeException', 'Object with ID already exists.');
         $manager->persist($persist2);
+    }
+
+    public function mappingDrivers()
+    {
+        return [
+            ['annotation'],
+            ['yaml'],
+        ];
     }
 }
 

--- a/tests/Doctrine/Tests/KeyValueStore/Functional/PersistTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Functional/PersistTest.php
@@ -20,7 +20,7 @@
 namespace Doctrine\Tests\KeyValueStore\Functional;
 
 use Doctrine\Tests\KeyValueStoreTestCase;
-use Doctrine\KeyValueStore\Mapping\Annotations as KVS;
+use Doctrine\KeyValueStore\Mapping as KVS;
 
 class PersistTest extends KeyValueStoreTestCase
 {

--- a/tests/Doctrine/Tests/KeyValueStoreTestCase.php
+++ b/tests/Doctrine/Tests/KeyValueStoreTestCase.php
@@ -21,19 +21,27 @@ namespace Doctrine\Tests;
 
 use Doctrine\KeyValueStore\EntityManager;
 use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\Mapping\AnnotationDriver;
+use Doctrine\KeyValueStore\Mapping\Driver;
 use Doctrine\KeyValueStore\Storage\DoctrineCacheStorage;
 use Doctrine\Common\Cache\ArrayCache;
 
 abstract class KeyValueStoreTestCase extends \PHPUnit_Framework_TestCase
 {
-    public function createManager($storage = null)
+    public function createManager($storage = null, $driver = 'annotation')
     {
         $cache = new ArrayCache;
         $storage = $storage ?: new DoctrineCacheStorage($cache);
 
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
-        $metadata = new AnnotationDriver($reader);
+        switch ($driver) {
+            case 'annotation':
+                $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+                $metadata = new Driver\AnnotationDriver($reader);
+
+                break;
+            case 'yaml':
+                $metadata = new Driver\YamlDriver(__DIR__.'/fixtures');
+        }
+
         $config = new Configuration();
         $config->setMappingDriverImpl($metadata);
         $config->setMetadataCache($cache);

--- a/tests/Doctrine/Tests/fixtures/Doctrine.Tests.KeyValueStore.Functional.ChildEntity.dcm.yml
+++ b/tests/Doctrine/Tests/fixtures/Doctrine.Tests.KeyValueStore.Functional.ChildEntity.dcm.yml
@@ -1,0 +1,3 @@
+Doctrine\Tests\KeyValueStore\Functional\ChildEntity:
+  id:
+  - id

--- a/tests/Doctrine/Tests/fixtures/Doctrine.Tests.KeyValueStore.Functional.ParentEntity.dcm.yml
+++ b/tests/Doctrine/Tests/fixtures/Doctrine.Tests.KeyValueStore.Functional.ParentEntity.dcm.yml
@@ -1,0 +1,3 @@
+Doctrine\Tests\KeyValueStore\Functional\ParentEntity:
+  id:
+  - id

--- a/tests/Doctrine/Tests/fixtures/Doctrine.Tests.KeyValueStore.Functional.PersistEntity.dcm.yml
+++ b/tests/Doctrine/Tests/fixtures/Doctrine.Tests.KeyValueStore.Functional.PersistEntity.dcm.yml
@@ -1,0 +1,3 @@
+Doctrine\Tests\KeyValueStore\Functional\PersistEntity:
+  id:
+  - id

--- a/tests/Doctrine/Tests/fixtures/Doctrine.Tests.KeyValueStore.Functional.Post.dcm.yml
+++ b/tests/Doctrine/Tests/fixtures/Doctrine.Tests.KeyValueStore.Functional.Post.dcm.yml
@@ -1,0 +1,4 @@
+Doctrine\Tests\KeyValueStore\Functional\Post:
+  storageName: post
+  id:
+  - id

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,6 @@ EOT
     );
 }
 
-\Doctrine\Common\Annotations\AnnotationRegistry::registerFile(__DIR__ . '/../lib/Doctrine/KeyValueStore/Mapping/Annotations/Entity.php');
-\Doctrine\Common\Annotations\AnnotationRegistry::registerFile(__DIR__ . '/../lib/Doctrine/KeyValueStore/Mapping/Annotations/Id.php');
-\Doctrine\Common\Annotations\AnnotationRegistry::registerFile(__DIR__ . '/../lib/Doctrine/KeyValueStore/Mapping/Annotations/Transient.php');
+\Doctrine\Common\Annotations\AnnotationRegistry::registerFile(__DIR__ . '/../lib/Doctrine/KeyValueStore/Mapping/Entity.php');
+\Doctrine\Common\Annotations\AnnotationRegistry::registerFile(__DIR__ . '/../lib/Doctrine/KeyValueStore/Mapping/Id.php');
+\Doctrine\Common\Annotations\AnnotationRegistry::registerFile(__DIR__ . '/../lib/Doctrine/KeyValueStore/Mapping/Transient.php');


### PR DESCRIPTION
Should be a solution (a first draft at least) for #13 

``` yaml
# Doctrine.Tests.KeyValueStore.Functional.Post.dcm.yml
Doctrine\Tests\KeyValueStore\Functional\Post:
  storageName: post
  id:
    - id
  transient:
    - foo
    - bar
```

The identifier can also be a string. A single attribute as identifier should be a common thing, I guess.