### PR TITLE
Implementation for Amazon DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Following vendors are targeted:
 * Doctrine\Common\Cache provider (Implemented)
 * RDBMS (Implemented)
 * Couchbase (Implemented)
-* Amazon DynamoDB
+* Amazon DynamoDB (Implemented)
 * CouchDB (Implemented)
 * Cassandra
 * MongoDB (Implemented)

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,13 @@
     "require": {
         "php": "^5.5|^7.0",
         "doctrine/common": "^2.4",
-        "doctrine/couchdb": "^1.0.0-beta4",
-        "aws/aws-sdk-php": "^3.8"
+        "doctrine/couchdb": "^1.0.0-beta4"
     },
     "require-dev": {
         "datastax/php-driver": "^1.0",
         "doctrine/couchdb": "^1.0.0-beta4",
         "phpunit/phpunit": "^4.8|^5.0",
-        "riak/riak-client": "dev-master"
+        "aws/aws-sdk-php": "^3.8"
     },
     "suggest": {
         "aws/aws-sdk-php": "to use the DynamoDB storage",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,9 @@
     "name": "doctrine/key-value-store",
     "require": {
         "php": "^5.5|^7.0",
-        "doctrine/common": "^2.4"
+        "doctrine/common": "^2.4",
+        "doctrine/couchdb": "^1.0.0-beta4",
+        "aws/aws-sdk-php": "^3.8"
     },
     "require-dev": {
         "datastax/php-driver": "^1.0",

--- a/lib/Doctrine/KeyValueStore/InvalidArgumentException.php
+++ b/lib/Doctrine/KeyValueStore/InvalidArgumentException.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore;
+
+
+class InvalidArgumentException extends KeyValueStoreException
+{
+    public static function invalidType($name, $expectedType, &$actual)
+    {
+        return new static(
+            sprintf('The %s must be a %s, got "%s" instead.', $name, $expectedType, gettype($actual)),
+            0
+        );
+    }
+
+    public static function invalidLength($name, $min, $max)
+    {
+        return new static(
+            sprintf('The %s must be at least %d but no more than %d chars.', $name, $min, $max),
+            0
+        );
+    }
+
+    public static function invalidTableName($name)
+    {
+        return new static(
+            sprintf('Invalid table name: %s', $name),
+            0
+        );
+    }
+}

--- a/lib/Doctrine/KeyValueStore/NotFoundException.php
+++ b/lib/Doctrine/KeyValueStore/NotFoundException.php
@@ -22,4 +22,8 @@ namespace Doctrine\KeyValueStore;
 
 class NotFoundException extends KeyValueStoreException
 {
+    public static function notFoundByKey($key)
+    {
+        return new static(sprintf('Could not find an item with key: %s', $key), 0);
+    }
 }

--- a/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
@@ -158,7 +158,7 @@ class AmazonDynamoDbStorage implements Storage
      *
      * @return string
      */
-    public function getKeyNameForTable($tableName)
+    private function getKeyNameForTable($tableName)
     {
         return isset($this->tableKeys[$tableName]) ?
             $this->tableKeys[$tableName] :
@@ -173,7 +173,7 @@ class AmazonDynamoDbStorage implements Storage
      *
      * @return array The key in DynamoDB format.
      */
-    private function  prepareKey($storageName, $key)
+    private function prepareKey($storageName, $key)
     {
         if (is_array($key)) {
             $keyValue = reset($key);

--- a/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
@@ -276,13 +276,10 @@ class AmazonDynamoDbStorage implements Storage
         ]);
 
         if (!$item) {
-            throw new NotFoundException();
+            throw NotFoundException::notFoundByKey($key);
         }
 
         $item = $item->get(self::TABLE_ITEM_KEY);
-        if (!is_array($item)) {
-            throw new NotFoundException();
-        }
 
         return $this->marshaler->unmarshalItem($item);
     }

--- a/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
@@ -1,0 +1,210 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore\Storage;
+
+use Aws\DynamoDb\DynamoDbClient;
+use Aws\DynamoDb\Marshaler;
+use Doctrine\KeyValueStore\NotFoundException;
+
+class AmazonDynamoDbStorage implements  Storage
+{
+    /**
+     * @var DynamoDbClient
+     */
+    private $client;
+
+    /**
+     * @var Marshaler
+     */
+    private $marshaler;
+
+    /**
+     * @var array
+     */
+    private $options = [
+        'default_key_name' => 'Id',
+        'storage_keys' => [],
+    ];
+
+    /**
+     * @param DynamoDbClient $client    The client for connecting to AWS DynamoDB.
+     * @param Marshaler|null $marshaler (optional) Marshaller for converting data to/from DynamoDB format.
+     * @param array          $options   (optional) Options to set which names to use for keys for the key/val store.
+     */
+    public function __construct(DynamoDbClient $client, Marshaler $marshaler = null, array $options = [])
+    {
+        $this->client = $client;
+        $this->marshaler = $marshaler ?: new Marshaler();
+        $this->options = array_merge($this->options, $options);
+    }
+
+    /**
+     * Retrieves a specific name for a key for a given storage name defaulting to 'default_key_name' option.
+     *
+     * @param string $storageName The name of the storage (i.e. table).
+     *
+     * @return string
+     */
+    protected function getKeyNameForStorage($storageName)
+    {
+        return isset($this->options['storage_keys'][$storageName]) ?
+            $this->options['storage_keys'][$storageName] :
+            $this->options['default_key_name'];
+    }
+
+    /**
+     * Prepares a key to be in a valid format for lookups for DynamoDB. If passing an array, that means that the key
+     * is the name of the key and the value is the actual value for the lookup.
+     *
+     * @param string $storageName
+     *
+     * @return array The key in DynamoDB format.
+     */
+    protected function prepareKey($storageName, $key)
+    {
+        if (is_array($key)) {
+            $keyValue = reset($key);
+            $keyName = key($key);
+        } else {
+            $keyValue = $key;
+            $keyName = $this->getKeyNameForStorage($storageName);
+        }
+
+        return $this->marshaler->marshalItem([$keyName => $keyValue]);
+    }
+
+    /**
+     * Determine if the storage supports updating only a subset of properties,
+     * or if all properties have to be set, even if only a subset of properties
+     * changed.
+     *
+     * @return bool
+     */
+    public function supportsPartialUpdates()
+    {
+        //This is not true, but partial updates are too complicated given the available interface,
+        //meaning, the abstraction is insufficiently flexible enough to support this type of action.
+        return false;
+    }
+
+    /**
+     * Does this storage support composite primary keys?
+     *
+     * @return bool
+     */
+    public function supportsCompositePrimaryKeys()
+    {
+        return true;
+    }
+
+    /**
+     * Does this storage require composite primary keys?
+     *
+     * @return bool
+     */
+    public function requiresCompositePrimaryKeys()
+    {
+        return false;
+    }
+
+    /**
+     * Insert data into the storage key specified.
+     *
+     * @param string       $storageName
+     * @param array|string $key
+     * @param array        $data
+     */
+    public function insert($storageName, $key, array $data)
+    {
+        $this->client->putItem([
+            'TableName' => $storageName,
+            'Item' => $this->prepareKey($storageName, $key) + $this->marshaler->marshalItem($data),
+        ]);
+    }
+
+    /**
+     * Update data into the given key.
+     *
+     * @param string       $storageName
+     * @param array|string $key
+     * @param array        $data
+     */
+    public function update($storageName, $key, array $data)
+    {
+        //We are using PUT so we just replace the original item
+        $this->insert($storageName, $key, $data);
+    }
+
+    /**
+     * Delete data at key.
+     *
+     * @param string       $storageName
+     * @param array|string $key
+     */
+    public function delete($storageName, $key)
+    {
+        $this->client->deleteItem([
+            'TableName' => $storageName,
+            'Key' => $this->prepareKey($storageName, $key),
+        ]);
+    }
+
+    /**
+     * Find data at key.
+     *
+     * Important note: The returned array does contain the identifier (again)!
+     *
+     * @throws NotFoundException When data with key is not found.
+     *
+     * @param string       $storageName
+     * @param array|string $key
+     *
+     * @return array
+     */
+    public function find($storageName, $key)
+    {
+        $item = $this->client->getItem([
+            'TableName' => $storageName,
+            'ConsistentRead' => true,
+            'Key' => $this->prepareKey($storageName, $key),
+        ]);
+
+        if (!$item) {
+            throw new NotFoundException();
+        }
+
+        $item = $item->get('Item');
+        if (!is_array($item)) {
+            throw new NotFoundException();
+        }
+
+        return $this->marshaler->unmarshalItem($item);
+    }
+
+    /**
+     * Return a name of the underlying storage.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'amazondynamodb';
+    }
+}

--- a/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
@@ -22,6 +22,7 @@ namespace Doctrine\KeyValueStore\Storage;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\Marshaler;
 use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\InvalidArgumentException;
 
 class AmazonDynamoDbStorage implements Storage
 {
@@ -82,14 +83,12 @@ class AmazonDynamoDbStorage implements Storage
     private function  validateKeyName($name)
     {
         if (!is_string($name)) {
-            throw new \InvalidArgumentException(
-                sprintf('The key must be a string, got "%s" instead.', gettype($name))
-            );
+            throw InvalidArgumentException::invalidType('key', 'string', $name);
         }
 
         $len = strlen($name);
         if ($len > 255 || $len < 1) {
-            throw new \InvalidArgumentException('The name must not exceed 255 bytes.');
+            throw InvalidArgumentException::invalidLength('name', 1, 255);
         }
     }
 
@@ -105,13 +104,11 @@ class AmazonDynamoDbStorage implements Storage
     private function  validateTableName($name)
     {
         if (!is_string($name)) {
-            throw new \InvalidArgumentException(
-                sprintf('The key must be a string, got "%s" instead.', gettype($name))
-            );
+            throw InvalidArgumentException::invalidType('key', 'string', $name);
         }
 
         if (!preg_match('/^[a-z0-9_.-]{3,255}$/i', $name)) {
-            throw new \InvalidArgumentException('Invalid DynamoDB table name.');
+            throw InvalidArgumentException::invalidTableName($name);
         }
     }
 
@@ -146,7 +143,7 @@ class AmazonDynamoDbStorage implements Storage
      *
      * @throws \InvalidArgumentException When the key or table name is invalid.
      */
-    public function setKeyForTable($table, $key)
+    private function setKeyForTable($table, $key)
     {
         $this->validateTableName($table);
         $this->validateKeyName($key);

--- a/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
@@ -78,7 +78,7 @@ class AmazonDynamoDbStorage implements Storage
      *
      * @param $name mixed The name to validate.
      *
-     * @throws \InvalidArgumentException When the key name is invalid.
+     * @throws InvalidArgumentException When the key name is invalid.
      */
     private function  validateKeyName($name)
     {
@@ -99,7 +99,7 @@ class AmazonDynamoDbStorage implements Storage
      *
      * @param $name string The table name to validate.
      *
-     * @throws \InvalidArgumentException When the name is invalid.
+     * @throws InvalidArgumentException When the name is invalid.
      */
     private function  validateTableName($name)
     {
@@ -117,7 +117,7 @@ class AmazonDynamoDbStorage implements Storage
      *
      * @param $name string The default name to use for the key.
      *
-     * @throws \InvalidArgumentException When the key name is invalid.
+     * @throws InvalidArgumentException When the key name is invalid.
      */
     public function setDefaultKeyName($name)
     {
@@ -141,7 +141,7 @@ class AmazonDynamoDbStorage implements Storage
      * @param $table string The name of the table.
      * @param $key string The name of the string.
      *
-     * @throws \InvalidArgumentException When the key or table name is invalid.
+     * @throws InvalidArgumentException When the key or table name is invalid.
      */
     private function setKeyForTable($table, $key)
     {
@@ -187,23 +187,18 @@ class AmazonDynamoDbStorage implements Storage
     }
 
     /**
-     * Determine if the storage supports updating only a subset of properties,
-     * or if all properties have to be set, even if only a subset of properties
-     * changed.
+     * This is not true, but partial updates are too complicated given the available interface, meaning,
+     * the abstraction is insufficiently flexible enough to support this type of action.
      *
-     * @return bool
+     * {@inheritdoc}
      */
     public function supportsPartialUpdates()
     {
-        //This is not true, but partial updates are too complicated given the available interface,
-        //meaning, the abstraction is insufficiently flexible enough to support this type of action.
         return false;
     }
 
     /**
-     * Does this storage support composite primary keys?
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function supportsCompositePrimaryKeys()
     {
@@ -211,9 +206,7 @@ class AmazonDynamoDbStorage implements Storage
     }
 
     /**
-     * Does this storage require composite primary keys?
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function requiresCompositePrimaryKeys()
     {
@@ -221,11 +214,7 @@ class AmazonDynamoDbStorage implements Storage
     }
 
     /**
-     * Insert data into the storage key specified.
-     *
-     * @param string       $storageName
-     * @param array|string $key
-     * @param array        $data
+     * {@inheritdoc}
      */
     public function insert($storageName, $key, array $data)
     {
@@ -236,11 +225,7 @@ class AmazonDynamoDbStorage implements Storage
     }
 
     /**
-     * Update data into the given key.
-     *
-     * @param string       $storageName
-     * @param array|string $key
-     * @param array        $data
+     * {@inheritdoc}
      */
     public function update($storageName, $key, array $data)
     {
@@ -249,10 +234,7 @@ class AmazonDynamoDbStorage implements Storage
     }
 
     /**
-     * Delete data at key.
-     *
-     * @param string       $storageName
-     * @param array|string $key
+     * {@inheritdoc}
      */
     public function delete($storageName, $key)
     {
@@ -263,16 +245,7 @@ class AmazonDynamoDbStorage implements Storage
     }
 
     /**
-     * Find data at key.
-     *
-     * Important note: The returned array does contain the identifier (again)!
-     *
-     * @throws NotFoundException When data with key is not found.
-     *
-     * @param string       $storageName
-     * @param array|string $key
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function find($storageName, $key)
     {
@@ -295,9 +268,7 @@ class AmazonDynamoDbStorage implements Storage
     }
 
     /**
-     * Return a name of the underlying storage.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
@@ -67,10 +67,8 @@ class AmazonDynamoDbStorage implements Storage
             $this->setDefaultKeyName($defaultKeyName);
         }
 
-        if (!empty($tableKeys)) {
-            foreach ($tableKeys as $table => $keyName) {
-                $this->setKeyForTable($table, $keyName);
-            }
+        foreach ($tableKeys as $table => $keyName) {
+            $this->setKeyForTable($table, $keyName);
         }
     }
 

--- a/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
@@ -79,7 +79,7 @@ class AmazonDynamoDbStorage implements Storage
      *
      * @throws \InvalidArgumentException When the key name is invalid.
      */
-    protected function validateKeyName($name)
+    private function  validateKeyName($name)
     {
         if (!is_string($name)) {
             throw new \InvalidArgumentException(
@@ -102,7 +102,7 @@ class AmazonDynamoDbStorage implements Storage
      *
      * @throws \InvalidArgumentException When the name is invalid.
      */
-    protected function validateTableName($name)
+    private function  validateTableName($name)
     {
         if (!is_string($name)) {
             throw new \InvalidArgumentException(
@@ -176,7 +176,7 @@ class AmazonDynamoDbStorage implements Storage
      *
      * @return array The key in DynamoDB format.
      */
-    protected function prepareKey($storageName, $key)
+    private function  prepareKey($storageName, $key)
     {
         if (is_array($key)) {
             $keyValue = reset($key);

--- a/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/AmazonDynamoDbStorage.php
@@ -23,7 +23,7 @@ use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\Marshaler;
 use Doctrine\KeyValueStore\NotFoundException;
 
-class AmazonDynamoDbStorage implements  Storage
+class AmazonDynamoDbStorage implements Storage
 {
     /**
      * @var DynamoDbClient

--- a/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Doctrine\Tests\KeyValueStore\Storage;
+
+use Aws\DynamoDb\DynamoDbClient;
+use Aws\Result;
+use Doctrine\KeyValueStore\Storage\AmazonDynamoDbStorage;
+
+class AmazonDynamoDbTest /*extends AbstractStorageTestCase */extends \PHPUnit_Framework_TestCase
+{
+    private function getDynamoDbMock($methods = [])
+    {
+        $client = $this->getMockBuilder(DynamoDbClient::class)->disableOriginalConstructor();
+
+        if (count($methods)) {
+            $client->setMethods($methods);
+        }
+
+        return $client->getMock();
+    }
+
+    private function getDynamoDbResultMock($methods = [])
+    {
+        $result = $this->getMockBuilder(Result::class)->disableOriginalConstructor();
+
+        if (count($methods)) {
+            $result->setMethods($methods);
+        }
+
+        return $result->getMock();
+    }
+
+    public function testTheStorageName()
+    {
+        $client = $this->getDynamoDbMock();
+
+        $storage = new AmazonDynamoDbStorage($client);
+        $this->assertSame('amazondynamodb', $storage->getName());
+    }
+
+    public function testOptionsMergedCorrectly()
+    {
+        $options = [
+            'storage_keys' => ['this' => 'that', 'yolo' => 'now']
+        ];
+
+        $shouldBe = [
+            'default_key_name' => 'Id',
+            'storage_keys' => ['this' => 'that', 'yolo' => 'now']
+        ];
+
+        $client = $this->getDynamoDbMock();
+
+        $storage = new AmazonDynamoDbStorage($client, null, $options);
+
+        $this->assertAttributeSame($shouldBe, 'options', $storage);
+    }
+
+    public function testThatSomeStorageHasDifferentKey()
+    {
+        $options = [
+            'default_key_name' => 'sauce',
+            'storage_keys' => ['this' => 'that', 'yolo' => 'now']
+        ];
+
+        $client = $this->getDynamoDbMock();
+
+        $storage = new AmazonDynamoDbStorage($client, null, $options);
+
+        $r = new \ReflectionObject($storage);
+        $method = $r->getMethod('prepareKey');
+        $method->setAccessible(true);
+        $this->assertSame(['that' => ['N' => '111']], $method->invoke($storage, 'this', 111));
+    }
+
+    public function testThatSomeStorageUsesDefaultKey()
+    {
+        $options = [
+            'default_key_name' => 'sauce',
+            'storage_keys' => ['this' => 'that', 'yolo' => 'now']
+        ];
+
+        $client = $this->getDynamoDbMock();
+
+        $storage = new AmazonDynamoDbStorage($client, null, $options);
+
+        $r = new \ReflectionObject($storage);
+        $method = $r->getMethod('prepareKey');
+        $method->setAccessible(true);
+        $this->assertSame(['sauce' => ['S' => 'hello']], $method->invoke($storage, 'MyTable', "hello"));
+    }
+
+    public function testInsertingCallsAPutItem()
+    {
+        $client = $this->getDynamoDbMock(['putItem']);
+
+        $client->expects($this->once())->method('putItem')->with($this->equalTo([
+            'TableName' => 'MyTable',
+            'Item' => [
+                'Id' => ['S' => 'stuff'],
+                'hi' => ['S' => 'there'],
+                'yo' => ['BOOL' => false],
+            ]
+        ]));
+
+        $storage = new AmazonDynamoDbStorage($client);
+        $storage->insert('MyTable', 'stuff', ['hi' => 'there', 'yo' => false]);
+    }
+
+    public function testUpdateActuallyAlsoCallsInsert()
+    {
+        $client = $this->getDynamoDbMock(['putItem']);
+
+        $client->expects($this->once())->method('putItem')->with($this->equalTo([
+            'TableName' => 'MyTable',
+            'Item' => [
+                'Id' => ['S' => 'stuff'],
+                'hi' => ['S' => 'there'],
+                'yo' => ['BOOL' => false],
+            ]
+        ]));
+
+        $storage = new AmazonDynamoDbStorage($client);
+        $storage->update('MyTable', 'stuff', ['hi' => 'there', 'yo' => false]);
+    }
+
+    public function testDeleteItem()
+    {
+        $client = $this->getDynamoDbMock(['deleteItem']);
+
+        $client->expects($this->once())->method('deleteItem')->with($this->equalTo([
+            'TableName' => 'MyTable',
+            'Key' => ['Id' => ['S' => 'abc123']]
+        ]));
+
+        $storage = new AmazonDynamoDbStorage($client);
+        $storage->delete('MyTable', 'abc123');
+    }
+
+    public function testPassingArrayAsKeyIsAPassthruToInsert()
+    {
+        $client = $this->getDynamoDbMock(['deleteItem']);
+
+        $client->expects($this->once())->method('deleteItem')->with($this->equalTo([
+            'TableName' => 'MyTable',
+            'Key' => ['Id' => ['S' => 'abc123']]
+        ]));
+
+        $storage = new AmazonDynamoDbStorage($client);
+        $storage->delete('MyTable', 'abc123');
+    }
+
+    /**
+     * @expectedException \Doctrine\KeyValueStore\NotFoundException
+     */
+    public function testTryingToFindAnItemThatDoesNotExist()
+    {
+        $client = $this->getDynamoDbMock(['getItem']);
+        $client->expects($this->once())->method('getItem')->with($this->equalTo([
+            'TableName' => 'MyTable',
+            'ConsistentRead' => true,
+            'Key' => ['Id' => ['N' => '1000']]
+        ]))->willReturn(null);
+
+        $storage = new AmazonDynamoDbStorage($client);
+        $storage->find('MyTable', 1000);
+    }
+
+    public function testFindAnItemThatExists()
+    {
+        $result = $this->getDynamoDbResultMock(['get']);
+        $result->expects($this->once())->method('get')->with('Item')->willReturn([
+            'hello' => ['S' => 'world']
+        ]);
+
+        $client = $this->getDynamoDbMock(['getItem']);
+        $client->expects($this->once())->method('getItem')->with($this->equalTo([
+            'TableName' => 'MyTable',
+            'ConsistentRead' => true,
+            'Key' => ['Id' => ['N' => '1000']]
+        ]))->willReturn($result);
+
+        $storage = new AmazonDynamoDbStorage($client);
+        $actualResult = $storage->find('MyTable', 1000);
+
+        $this->assertSame(['hello' => 'world'], $actualResult);
+    }
+}

--- a/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
@@ -71,34 +71,34 @@ class AmazonDynamoDbTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame([], 'tableKeys', $storage);
     }
 
-    /**
-     * @expectedException \Doctrine\KeyValueStore\KeyValueStoreException
-     * @expectedExceptionMessage The key must be a string, got "array" instead.
-     */
     public function testDefaultKeyCannotBeSomethingOtherThanString()
     {
         $client = $this->getDynamoDbMock();
+        $this->setExpectedException(
+            '\Doctrine\KeyValueStore\KeyValueStoreException',
+            'The key must be a string, got "array" instead.'
+        );
         new AmazonDynamoDbStorage($client, null, []);
     }
 
-    /**
-     * @expectedException \Doctrine\KeyValueStore\KeyValueStoreException
-     * @expectedExceptionMessage The key must be a string, got "object" instead.
-     */
     public function testTableKeysMustAllBeStringsOrElse()
     {
         $client = $this->getDynamoDbMock();
+        $this->setExpectedException(
+            '\Doctrine\KeyValueStore\KeyValueStoreException',
+            'The key must be a string, got "object" instead.'
+        );
         new AmazonDynamoDbStorage($client, null, null, ['mytable' => 'hello', 'yourtable' => new \stdClass()]);
     }
 
-    /**
-     * @expectedException \Doctrine\KeyValueStore\KeyValueStoreException
-     * @expectedExceptionMessage The name must be at least 1 but no more than 255 chars.
-     */
     public function testKeyNameMustBeUnder255Bytes()
     {
         $client = $this->getDynamoDbMock();
         $storage = new AmazonDynamoDbStorage($client);
+        $this->setExpectedException(
+            '\Doctrine\KeyValueStore\KeyValueStoreException',
+            'The name must be at least 1 but no more than 255 chars.'
+        );
         $storage->setDefaultKeyName(str_repeat('a', 256));
     }
 
@@ -137,12 +137,12 @@ class AmazonDynamoDbTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider invalidTableNames
-     * @expectedException \Doctrine\KeyValueStore\KeyValueStoreException
      */
     public function testTableNameValidatesAgainstInvalidTableNames($tableName)
     {
         $client = $this->getDynamoDbMock();
         $storage = new AmazonDynamoDbStorage($client);
+        $this->setExpectedException('\Doctrine\KeyValueStore\KeyValueStoreException');
         $this->invokeMethod('setKeyForTable', $storage, [$tableName, 'Id']);
     }
 
@@ -267,9 +267,6 @@ class AmazonDynamoDbTest extends \PHPUnit_Framework_TestCase
         $storage->delete('MyTable', 'abc123');
     }
 
-    /**
-     * @expectedException \Doctrine\KeyValueStore\NotFoundException
-     */
     public function testTryingToFindAnItemThatDoesNotExist()
     {
         $client = $this->getDynamoDbMock(['getItem']);
@@ -280,6 +277,10 @@ class AmazonDynamoDbTest extends \PHPUnit_Framework_TestCase
         ]))->willReturn(null);
 
         $storage = new AmazonDynamoDbStorage($client);
+        $this->setExpectedException(
+            '\Doctrine\KeyValueStore\NotFoundException',
+            'Could not find an item with key: 1000'
+        );
         $storage->find('MyTable', 1000);
     }
 

--- a/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
@@ -1,9 +1,30 @@
 <?php
 
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
 namespace Doctrine\Tests\KeyValueStore\Storage;
 
 use Doctrine\KeyValueStore\Storage\AmazonDynamoDbStorage;
 
+/**
+ * @covers \Doctrine\KeyValueStory\Storage\AmazonDynamoDbStorage
+ */
 class AmazonDynamoDbTest extends \PHPUnit_Framework_TestCase
 {
     private function getDynamoDbMock($methods = [])

--- a/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
@@ -158,14 +158,14 @@ class AmazonDynamoDbTest extends \PHPUnit_Framework_TestCase
     {
         $client = $this->getDynamoDbMock();
         $storage = new AmazonDynamoDbStorage($client, null, 'CustomKey');
-        $this->assertSame('CustomKey', $storage->getKeyNameForTable('whatever_this_is'));
+        $this->assertSame('CustomKey', $this->invokeMethod('getKeyNameForTable', $storage, ['whatever_this_is']));
     }
 
     public function testGetWillReturnCorrectKeyForRecognizedTableName()
     {
         $client = $this->getDynamoDbMock();
         $storage = new AmazonDynamoDbStorage($client, null, 'CustomKey', ['MyTable' => 'Yesss']);
-        $this->assertSame('Yesss', $storage->getKeyNameForTable('MyTable'));
+        $this->assertSame('Yesss', $this->invokeMethod('getKeyNameForTable', $storage, ['MyTable']));
     }
 
     public function testThatSomeStorageHasDifferentKey()

--- a/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Storage/AmazonDynamoDbTest.php
@@ -6,7 +6,7 @@ use Aws\DynamoDb\DynamoDbClient;
 use Aws\Result;
 use Doctrine\KeyValueStore\Storage\AmazonDynamoDbStorage;
 
-class AmazonDynamoDbTest /*extends AbstractStorageTestCase */extends \PHPUnit_Framework_TestCase
+class AmazonDynamoDbTest extends \PHPUnit_Framework_TestCase
 {
     private function getDynamoDbMock($methods = [])
     {


### PR DESCRIPTION
Added an implementation for Amazon DynamoDB. Using the `$options` key to the constructor, you can set which `$storageName` uses which key name for access. For example, if your key-val store called `Awesome` uses a key called `MyKey` then you can set it like so:

```php
$credentials = new \Aws\Credentials\Credentials('yo', 'sup');

$aws = new \Aws\Sdk([
    'timeout' => 1,
    'credentials' => $credentials,
    'region' => 'us-west-2',
    'version' => 'latest',
    'endpoint' => 'http://127.0.0.1:11888',
]);

$storage = new AmazonDynamoDbStorage(
    $aws->createDynamoDb(),
    null,
    ['storage_keys' => ['Awesome' => 'MyKey']]
);
```

Otherwise, the option `default_key_name` which defaults to `Id` will be used as the key name.
