### PR TITLE
Added deprecation annotation

### DIFF
--- a/lib/Doctrine/KeyValueStore/Http/Client.php
+++ b/lib/Doctrine/KeyValueStore/Http/Client.php
@@ -23,6 +23,7 @@ namespace Doctrine\KeyValueStore\Http;
  * Yet another HTTP client
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @deprecated This class is deprecated and will be removed in 2.0.
  */
 interface Client
 {

--- a/lib/Doctrine/KeyValueStore/Http/Response.php
+++ b/lib/Doctrine/KeyValueStore/Http/Response.php
@@ -23,6 +23,7 @@ namespace Doctrine\KeyValueStore\Http;
  * HTTP Response
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @deprecated This class is deprecated and will be removed in 2.0.
  */
 class Response
 {

--- a/lib/Doctrine/KeyValueStore/Http/SocketClient.php
+++ b/lib/Doctrine/KeyValueStore/Http/SocketClient.php
@@ -28,6 +28,7 @@ namespace Doctrine\KeyValueStore\Http;
  * @link        www.doctrine-project.com
  * @since       1.0
  * @author      Kore Nordmann <kore@arbitracker.org>
+ * @deprecated  This class is deprecated and will be removed in 2.0.
  */
 class SocketClient implements Client
 {

--- a/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTable/AuthorizationSchema.php
+++ b/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTable/AuthorizationSchema.php
@@ -24,6 +24,7 @@ namespace Doctrine\KeyValueStore\Storage\WindowsAzureTable;
  *
  * @link http://msdn.microsoft.com/en-us/library/windowsazure/dd179428.aspx
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @deprecated This class is deprecated and will be removed in 2.0.
  */
 interface AuthorizationSchema
 {

--- a/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTable/HttpStorageException.php
+++ b/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTable/HttpStorageException.php
@@ -21,6 +21,9 @@ namespace Doctrine\KeyValueStore\Storage\WindowsAzureTable;
 
 use Doctrine\KeyValueStore\Storage\StorageException;
 
+/**
+ * @deprecated This class is deprecated and will be removed in 2.0.
+ */
 class HttpStorageException extends StorageException
 {
 }

--- a/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTable/SharedKeyAuthorization.php
+++ b/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTable/SharedKeyAuthorization.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\KeyValueStore\Storage\WindowsAzureTable;
 
+/**
+ * @deprecated This class is deprecated and will be removed in 2.0.
+ */
 class SharedKeyAuthorization implements AuthorizationSchema
 {
     /**

--- a/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTable/SharedKeyLiteAuthorization.php
+++ b/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTable/SharedKeyLiteAuthorization.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\KeyValueStore\Storage\WindowsAzureTable;
 
+/**
+ * @deprecated This class is deprecated and will be removed in 2.0.
+ */
 class SharedKeyLiteAuthorization implements AuthorizationSchema
 {
     /**

--- a/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTableStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/WindowsAzureTableStorage.php
@@ -32,7 +32,7 @@ use Doctrine\KeyValueStore\NotFoundException;
  * Using a HTTP client to communicate with the REST API of Azure Table.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @deprecated Use the AzureSdkTableStorage instead, this will be unmaintained.
+ * @deprecated This class is deprecated and will be removed in 2.0, use the AzureSdkTableStorage instead.
  */
 class WindowsAzureTableStorage implements Storage, RangeQueryStorage
 {


### PR DESCRIPTION
These classes are currently used only for the deprecated `WindowsAzureTableStorage`, so imo should be marked as deprecated too.