### PR TITLE
Moved to a more structured hierarchy

### DIFF
--- a/lib/Doctrine/KeyValueStore/Configuration.php
+++ b/lib/Doctrine/KeyValueStore/Configuration.php
@@ -46,7 +46,9 @@ class Configuration
     public function getMappingDriverImpl()
     {
         if (! isset($this->config['mappingDriver'])) {
-            throw KeyValueStoreException::mappingDriverMissing();
+            throw new Exception\Exception(
+                'No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()'
+            );
         }
 
         return $this->config['mappingDriver'];

--- a/lib/Doctrine/KeyValueStore/Exception.php
+++ b/lib/Doctrine/KeyValueStore/Exception.php
@@ -18,37 +18,8 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\Tests\KeyValueStore;
+namespace Doctrine\KeyValueStore;
 
-use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\Exception\Exception;
-
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+interface Exception
 {
-    public function testNoMappingDriver()
-    {
-        $config = new Configuration();
-
-        $this->setExpectedException(
-            Exception::class,
-            'No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()'
-        );
-        $config->getMappingDriverImpl();
-    }
-
-    public function testDefaultCacheDriver()
-    {
-        $config = new Configuration();
-        $cache  = $config->getMetadataCache();
-
-        $this->assertInstanceOf('Doctrine\Common\Cache\Cache', $cache);
-    }
-
-    public function testDefaultIdConverterStrategy()
-    {
-        $config   = new Configuration();
-        $strategy = $config->getIdConverterStrategy();
-
-        $this->assertInstanceOf('Doctrine\KeyValueStore\Id\NullIdConverter', $strategy);
-    }
 }

--- a/lib/Doctrine/KeyValueStore/Exception/Exception.php
+++ b/lib/Doctrine/KeyValueStore/Exception/Exception.php
@@ -18,10 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore\Storage;
+namespace Doctrine\KeyValueStore\Exception;
 
-use Doctrine\KeyValueStore\KeyValueStoreException;
+use Doctrine\KeyValueStore\Exception as BaseException;
 
-class StorageException extends KeyValueStoreException
+class Exception extends \Exception implements BaseException
 {
 }

--- a/lib/Doctrine/KeyValueStore/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/KeyValueStore/Exception/InvalidArgumentException.php
@@ -18,37 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\Tests\KeyValueStore;
+namespace Doctrine\KeyValueStore\Exception;
 
-use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\Exception\Exception;
+use Doctrine\KeyValueStore\Exception as BaseException;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class InvalidArgumentException extends \InvalidArgumentException implements BaseException
 {
-    public function testNoMappingDriver()
-    {
-        $config = new Configuration();
-
-        $this->setExpectedException(
-            Exception::class,
-            'No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()'
-        );
-        $config->getMappingDriverImpl();
-    }
-
-    public function testDefaultCacheDriver()
-    {
-        $config = new Configuration();
-        $cache  = $config->getMetadataCache();
-
-        $this->assertInstanceOf('Doctrine\Common\Cache\Cache', $cache);
-    }
-
-    public function testDefaultIdConverterStrategy()
-    {
-        $config   = new Configuration();
-        $strategy = $config->getIdConverterStrategy();
-
-        $this->assertInstanceOf('Doctrine\KeyValueStore\Id\NullIdConverter', $strategy);
-    }
 }

--- a/lib/Doctrine/KeyValueStore/Exception/NotFoundException.php
+++ b/lib/Doctrine/KeyValueStore/Exception/NotFoundException.php
@@ -18,37 +18,8 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\Tests\KeyValueStore;
+namespace Doctrine\KeyValueStore\Exception;
 
-use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\Exception\Exception;
-
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class NotFoundException extends Exception
 {
-    public function testNoMappingDriver()
-    {
-        $config = new Configuration();
-
-        $this->setExpectedException(
-            Exception::class,
-            'No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()'
-        );
-        $config->getMappingDriverImpl();
-    }
-
-    public function testDefaultCacheDriver()
-    {
-        $config = new Configuration();
-        $cache  = $config->getMetadataCache();
-
-        $this->assertInstanceOf('Doctrine\Common\Cache\Cache', $cache);
-    }
-
-    public function testDefaultIdConverterStrategy()
-    {
-        $config   = new Configuration();
-        $strategy = $config->getIdConverterStrategy();
-
-        $this->assertInstanceOf('Doctrine\KeyValueStore\Id\NullIdConverter', $strategy);
-    }
 }

--- a/lib/Doctrine/KeyValueStore/Exception/RuntimeException.php
+++ b/lib/Doctrine/KeyValueStore/Exception/RuntimeException.php
@@ -18,8 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore;
+namespace Doctrine\KeyValueStore\Exception;
 
-class NotFoundException extends KeyValueStoreException
+use Doctrine\KeyValueStore\Exception as BaseException;
+
+class RuntimeException extends \RuntimeException implements BaseException
 {
 }

--- a/lib/Doctrine/KeyValueStore/Id/CompositeIdHandler.php
+++ b/lib/Doctrine/KeyValueStore/Id/CompositeIdHandler.php
@@ -29,12 +29,12 @@ class CompositeIdHandler implements IdHandlingStrategy
         if (! $metadata->isCompositeKey && ! is_array($key)) {
             $id = [$metadata->identifier[0] => $key];
         } elseif (! is_array($key)) {
-            throw new \InvalidArgumentException('Array of identifier key-value pairs is expected!');
+            throw new Exception\InvalidArgumentException('Array of identifier key-value pairs is expected!');
         } else {
             $id = [];
             foreach ($metadata->identifier as $field) {
                 if (! isset($key[$field])) {
-                    throw new \InvalidArgumentException(
+                    throw new Exception\InvalidArgumentException(
                         "Missing identifier field $field in request for the primary key."
                     );
                 }

--- a/lib/Doctrine/KeyValueStore/Id/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/KeyValueStore/Id/Exception/InvalidArgumentException.php
@@ -18,37 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\Tests\KeyValueStore;
+namespace Doctrine\KeyValueStore\Id\Exception;
 
-use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\Exception\Exception;
+use Doctrine\KeyValueStore\Exception\InvalidArgumentException as BaseInvalidArgumentException;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class InvalidArgumentException extends BaseInvalidArgumentException
 {
-    public function testNoMappingDriver()
-    {
-        $config = new Configuration();
-
-        $this->setExpectedException(
-            Exception::class,
-            'No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()'
-        );
-        $config->getMappingDriverImpl();
-    }
-
-    public function testDefaultCacheDriver()
-    {
-        $config = new Configuration();
-        $cache  = $config->getMetadataCache();
-
-        $this->assertInstanceOf('Doctrine\Common\Cache\Cache', $cache);
-    }
-
-    public function testDefaultIdConverterStrategy()
-    {
-        $config   = new Configuration();
-        $strategy = $config->getIdConverterStrategy();
-
-        $this->assertInstanceOf('Doctrine\KeyValueStore\Id\NullIdConverter', $strategy);
-    }
 }

--- a/lib/Doctrine/KeyValueStore/Mapping/AnnotationDriver.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/AnnotationDriver.php
@@ -60,7 +60,7 @@ class AnnotationDriver implements MappingDriver
 
         $entityAnnot = $this->reader->getClassAnnotation($class, 'Doctrine\KeyValueStore\Mapping\Annotations\Entity');
         if (! $entityAnnot) {
-            throw new \InvalidArgumentException($metadata->name . ' is not a valid key-value-store entity.');
+            throw new Exception\InvalidArgumentException($metadata->name . ' is not a valid key-value-store entity.');
         }
         $metadata->storageName = $entityAnnot->storageName;
 

--- a/lib/Doctrine/KeyValueStore/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/ClassMetadataFactory.php
@@ -46,7 +46,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     protected function getFqcnFromAlias($namespaceAlias, $simpleClassName)
     {
-        throw new \InvalidArgumentException('aliasing is not supported.');
+        throw new Exception\InvalidArgumentException('aliasing is not supported.');
     }
 
     protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents)
@@ -64,7 +64,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         }
 
         if (! $class->identifier) {
-            throw new \InvalidArgumentException('Class ' . $class->name . ' has no identifier.');
+            throw new Exception\InvalidArgumentException('Class ' . $class->name . ' has no identifier.');
         }
     }
 

--- a/lib/Doctrine/KeyValueStore/Mapping/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/Exception/InvalidArgumentException.php
@@ -18,37 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\Tests\KeyValueStore;
+namespace Doctrine\KeyValueStore\Mapping\Exception;
 
-use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\Exception\Exception;
+use Doctrine\KeyValueStore\Exception\InvalidArgumentException as BaseInvalidArgumentException;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class InvalidArgumentException extends BaseInvalidArgumentException
 {
-    public function testNoMappingDriver()
-    {
-        $config = new Configuration();
-
-        $this->setExpectedException(
-            Exception::class,
-            'No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()'
-        );
-        $config->getMappingDriverImpl();
-    }
-
-    public function testDefaultCacheDriver()
-    {
-        $config = new Configuration();
-        $cache  = $config->getMetadataCache();
-
-        $this->assertInstanceOf('Doctrine\Common\Cache\Cache', $cache);
-    }
-
-    public function testDefaultIdConverterStrategy()
-    {
-        $config   = new Configuration();
-        $strategy = $config->getIdConverterStrategy();
-
-        $this->assertInstanceOf('Doctrine\KeyValueStore\Id\NullIdConverter', $strategy);
-    }
 }

--- a/lib/Doctrine/KeyValueStore/Mapping/XmlDriver.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/XmlDriver.php
@@ -70,11 +70,11 @@ class XmlDriver extends FileDriver
         try {
             $xmlRoot = $this->getElement($className);
         } catch (MappingException $exception) {
-            throw new \InvalidArgumentException($metadata->name . ' is not a valid key-value-store entity.');
+            throw new Exception\InvalidArgumentException($metadata->name . ' is not a valid key-value-store entity.');
         }
 
         if ($xmlRoot->getName() != 'entity') {
-            throw new \InvalidArgumentException($metadata->name . ' is not a valid key-value-store entity.');
+            throw new Exception\InvalidArgumentException($metadata->name . ' is not a valid key-value-store entity.');
         }
 
         $class = new \ReflectionClass($className);

--- a/lib/Doctrine/KeyValueStore/Mapping/YamlDriver.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/YamlDriver.php
@@ -62,7 +62,7 @@ class YamlDriver extends FileDriver
         try {
             $element = $this->getElement($className);
         } catch (MappingException $exception) {
-            throw new \InvalidArgumentException($metadata->name . ' is not a valid key-value-store entity.');
+            throw new Exception\InvalidArgumentException($metadata->name . ' is not a valid key-value-store entity.');
         }
 
         $class = new \ReflectionClass($className);

--- a/lib/Doctrine/KeyValueStore/Query/Exception/RuntimeException.php
+++ b/lib/Doctrine/KeyValueStore/Query/Exception/RuntimeException.php
@@ -18,37 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\Tests\KeyValueStore;
+namespace Doctrine\KeyValueStore\Query\Exception;
 
-use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\Exception\Exception;
+use Doctrine\KeyValueStore\Exception\RuntimeException as BaseRuntimeException;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class RuntimeException extends BaseRuntimeException
 {
-    public function testNoMappingDriver()
-    {
-        $config = new Configuration();
-
-        $this->setExpectedException(
-            Exception::class,
-            'No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()'
-        );
-        $config->getMappingDriverImpl();
-    }
-
-    public function testDefaultCacheDriver()
-    {
-        $config = new Configuration();
-        $cache  = $config->getMetadataCache();
-
-        $this->assertInstanceOf('Doctrine\Common\Cache\Cache', $cache);
-    }
-
-    public function testDefaultIdConverterStrategy()
-    {
-        $config   = new Configuration();
-        $strategy = $config->getIdConverterStrategy();
-
-        $this->assertInstanceOf('Doctrine\KeyValueStore\Id\NullIdConverter', $strategy);
-    }
 }

--- a/lib/Doctrine/KeyValueStore/Query/RangeQuery.php
+++ b/lib/Doctrine/KeyValueStore/Query/RangeQuery.php
@@ -209,7 +209,7 @@ class RangeQuery
         $storage = $this->em->unwrap();
 
         if (! $storage instanceof RangeQueryStorage) {
-            throw new \RuntimeException(
+            throw new Exception\RuntimeException(
                 'The storage backend ' . $storage->getName() . ' does not support range queries.'
             );
         }

--- a/lib/Doctrine/KeyValueStore/Storage/AzureSdkTableStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/AzureSdkTableStorage.php
@@ -20,7 +20,7 @@
 
 namespace Doctrine\KeyValueStore\Storage;
 
-use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\Exception\NotFoundException;
 use Doctrine\KeyValueStore\Query\RangeQuery;
 use Doctrine\KeyValueStore\Query\RangeQueryStorage;
 use WindowsAzure\Common\ServiceException;
@@ -82,7 +82,7 @@ class AzureSdkTableStorage implements Storage, RangeQueryStorage
             if ($e->getCode() == 404) {
                 $this->client->createTable($storageName);
             } else {
-                throw new StorageException(
+                throw new Exception\Exception(
                     'Could not save entity in table, WindowsAzure SDK client reported error: ' . $e->getMessage(),
                     $e->getCode(),
                     $e
@@ -101,7 +101,7 @@ class AzureSdkTableStorage implements Storage, RangeQueryStorage
         try {
             $this->client->updateEntity($storageName, $entity);
         } catch (ServiceException $e) {
-            throw new StorageException(
+            throw new Exception\Exception(
                 'Could not update entity in table, WindowsAzure SDK client reported error: ' . $e->getMessage(),
                 $e->getCode(),
                 $e
@@ -119,7 +119,7 @@ class AzureSdkTableStorage implements Storage, RangeQueryStorage
         try {
             $this->client->deleteEntity($storageName, $partitonKey, $rowKey);
         } catch (ServiceException $e) {
-            throw new StorageException(
+            throw new Exception\Exception(
                 'Could not delete entity in table, WindowsAzure SDK client reported error: ' . $e->getMessage(),
                 $e->getCode(),
                 $e
@@ -140,7 +140,7 @@ class AzureSdkTableStorage implements Storage, RangeQueryStorage
             if ($e->getCode() === 404) {
                 throw new NotFoundException();
             } else {
-                throw new StorageException(
+                throw new Exception\Exception(
                     'Could not find entity in table, WindowsAzure SDK client reported error: ' . $e->getMessage(),
                     $e->getCode(),
                     $e
@@ -185,7 +185,7 @@ class AzureSdkTableStorage implements Storage, RangeQueryStorage
 
         foreach ($query->getConditions() as $condition) {
             if (! in_array($condition[0], ['eq', 'neq', 'le', 'lt', 'ge', 'gt'])) {
-                throw new \InvalidArgumentException(
+                throw new Exception\InvalidArgumentException(
                     'Windows Azure Table only supports eq, neq, le, lt, ge, gt as conditions.'
                 );
             }

--- a/lib/Doctrine/KeyValueStore/Storage/CassandraStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/CassandraStorage.php
@@ -22,7 +22,7 @@ namespace Doctrine\KeyValueStore\Storage;
 
 use Cassandra\ExecutionOptions;
 use Cassandra\Session;
-use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\Exception\NotFoundException;
 
 /**
  * Cassandra Storage Engine for KeyValueStore.

--- a/lib/Doctrine/KeyValueStore/Storage/CouchDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/CouchDbStorage.php
@@ -116,7 +116,7 @@ final class CouchDbStorage implements Storage
     /**
      * @param string       $storageName
      * @param array|string $key
-     * 
+     *
      * @return string
      */
     private function flattenKey($storageName, $key)
@@ -128,7 +128,7 @@ final class CouchDbStorage implements Storage
         }
 
         if (! is_array($key)) {
-            throw new \InvalidArgumentException('The key should be a string or a flat array.');
+            throw new Exception\InvalidArgumentException('The key should be a string or a flat array.');
         }
 
         foreach ($key as $property => $value) {

--- a/lib/Doctrine/KeyValueStore/Storage/CouchbaseStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/CouchbaseStorage.php
@@ -20,7 +20,7 @@
 
 namespace Doctrine\KeyValueStore\Storage;
 
-use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\Exception\NotFoundException;
 
 /**
  * @author Simon Schick <simonsimcity@gmail.com>

--- a/lib/Doctrine/KeyValueStore/Storage/DBALStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/DBALStorage.php
@@ -21,7 +21,7 @@
 namespace Doctrine\KeyValueStore\Storage;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\Exception\NotFoundException;
 
 /**
  * Relational databased backed system.

--- a/lib/Doctrine/KeyValueStore/Storage/DynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/DynamoDbStorage.php
@@ -23,7 +23,7 @@ namespace Doctrine\KeyValueStore\Storage;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\Exception\ResourceNotFoundException;
 use Aws\DynamoDb\Iterator\ItemIterator;
-use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\Exception\NotFoundException;
 
 /**
  * DyanmoDb storage

--- a/lib/Doctrine/KeyValueStore/Storage/Exception/Exception.php
+++ b/lib/Doctrine/KeyValueStore/Storage/Exception/Exception.php
@@ -18,37 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\Tests\KeyValueStore;
+namespace Doctrine\KeyValueStore\Storage\Exception;
 
-use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\Exception\Exception;
+use Doctrine\KeyValueStore\Exception\Exception as BaseException;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class Exception extends BaseException
 {
-    public function testNoMappingDriver()
-    {
-        $config = new Configuration();
-
-        $this->setExpectedException(
-            Exception::class,
-            'No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()'
-        );
-        $config->getMappingDriverImpl();
-    }
-
-    public function testDefaultCacheDriver()
-    {
-        $config = new Configuration();
-        $cache  = $config->getMetadataCache();
-
-        $this->assertInstanceOf('Doctrine\Common\Cache\Cache', $cache);
-    }
-
-    public function testDefaultIdConverterStrategy()
-    {
-        $config   = new Configuration();
-        $strategy = $config->getIdConverterStrategy();
-
-        $this->assertInstanceOf('Doctrine\KeyValueStore\Id\NullIdConverter', $strategy);
-    }
 }

--- a/lib/Doctrine/KeyValueStore/Storage/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/KeyValueStore/Storage/Exception/InvalidArgumentException.php
@@ -18,12 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore;
+namespace Doctrine\KeyValueStore\Storage\Exception;
 
-class KeyValueStoreException extends \Exception
+use Doctrine\KeyValueStore\Exception\InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidArgumentException extends BaseInvalidArgumentException
 {
-    public static function mappingDriverMissing()
-    {
-        return new self('No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()');
-    }
 }

--- a/lib/Doctrine/KeyValueStore/Storage/Exception/RuntimeException.php
+++ b/lib/Doctrine/KeyValueStore/Storage/Exception/RuntimeException.php
@@ -18,37 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\Tests\KeyValueStore;
+namespace Doctrine\KeyValueStore\Storage\Exception;
 
-use Doctrine\KeyValueStore\Configuration;
-use Doctrine\KeyValueStore\Exception\Exception;
+use Doctrine\KeyValueStore\Exception\RuntimeException as BaseRuntimeException;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class RuntimeException extends BaseRuntimeException
 {
-    public function testNoMappingDriver()
-    {
-        $config = new Configuration();
-
-        $this->setExpectedException(
-            Exception::class,
-            'No mapping driver was assigned to the configuration. Use $config->setMappingDriverImpl()'
-        );
-        $config->getMappingDriverImpl();
-    }
-
-    public function testDefaultCacheDriver()
-    {
-        $config = new Configuration();
-        $cache  = $config->getMetadataCache();
-
-        $this->assertInstanceOf('Doctrine\Common\Cache\Cache', $cache);
-    }
-
-    public function testDefaultIdConverterStrategy()
-    {
-        $config   = new Configuration();
-        $strategy = $config->getIdConverterStrategy();
-
-        $this->assertInstanceOf('Doctrine\KeyValueStore\Id\NullIdConverter', $strategy);
-    }
 }

--- a/lib/Doctrine/KeyValueStore/Storage/MongoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/MongoDbStorage.php
@@ -20,7 +20,7 @@
 
 namespace Doctrine\KeyValueStore\Storage;
 
-use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\Exception\NotFoundException;
 
 /**
  * MongoDb storage
@@ -71,10 +71,10 @@ class MongoDbStorage implements Storage
         }
 
         if (empty($this->dbOptions['database'])) {
-            throw new \RuntimeException('The option "database" must be set');
+            throw new Exception\RuntimeException('The option "database" must be set');
         }
         if (empty($this->dbOptions['collection'])) {
-            throw new \RuntimeException('The option "collection" must be set');
+            throw new Exception\RuntimeException('The option "collection" must be set');
         }
 
         $this->collection = $this

--- a/lib/Doctrine/KeyValueStore/Storage/RedisStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/RedisStorage.php
@@ -20,7 +20,7 @@
 
 namespace Doctrine\KeyValueStore\Storage;
 
-use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\Exception\NotFoundException;
 
 /**
  * @author Marcel Araujo <admin@marcelaraujo.me>

--- a/lib/Doctrine/KeyValueStore/Storage/RiakStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/RiakStorage.php
@@ -20,7 +20,7 @@
 
 namespace Doctrine\KeyValueStore\Storage;
 
-use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\Exception\NotFoundException;
 use Riak\Client;
 
 /**

--- a/lib/Doctrine/KeyValueStore/Storage/SimpleDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/SimpleDbStorage.php
@@ -23,8 +23,8 @@ namespace Doctrine\KeyValueStore\Storage;
 use Aws\SimpleDb\Exception\NoSuchDomainException;
 use Aws\SimpleDb\Exception\SimpleDbException;
 use Aws\SimpleDb\SimpleDbClient;
-use Doctrine\KeyValueStore\KeyValueStoreException;
-use Doctrine\KeyValueStore\NotFoundException;
+use Doctrine\KeyValueStore\Exception\Exception as KeyValueStoreException;
+use Doctrine\KeyValueStore\Exception\NotFoundException;
 
 /**
  * SimpleDb storage

--- a/lib/Doctrine/KeyValueStore/Storage/Storage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/Storage.php
@@ -99,7 +99,7 @@ interface Storage
      * @param string       $storageName
      * @param array|string $key
      *
-     * @throws Doctrine\KeyValueStore\NotFoundException When data with key is not found.
+     * @throws Doctrine\KeyValueStore\Exception\NotFoundException When data with key is not found.
      *
      * @return array
      */

--- a/lib/Doctrine/KeyValueStore/UnitOfWork.php
+++ b/lib/Doctrine/KeyValueStore/UnitOfWork.php
@@ -92,7 +92,7 @@ class UnitOfWork
         $data  = $this->storageDriver->find($class->storageName, $id);
 
         if (! $data) {
-            throw new NotFoundException();
+            throw new Exception\NotFoundException();
         }
 
         return $this->createEntity($class, $id, $data);
@@ -102,7 +102,7 @@ class UnitOfWork
     {
         if (isset($data['php_class'])) {
             if ($data['php_class'] !== $class->name && ! is_subclass_of($data['php_class'], $class->name)) {
-                throw new \RuntimeException(
+                throw new Exception\RuntimeException(
                     "Row is of class '" . $data['php_class'] . "' which is not a subtype of expected " . $class->name
                 );
             }
@@ -184,13 +184,13 @@ class UnitOfWork
         $id    = $this->idHandler->getIdentifier($class, $object);
 
         if (! $id) {
-            throw new \RuntimeException('Trying to persist entity that has no id.');
+            throw new Exception\RuntimeException('Trying to persist entity that has no id.');
         }
 
         $idHash = $this->idHandler->hash($id);
 
         if (isset($this->identityMap[$class->name][$idHash])) {
-            throw new \RuntimeException('Object with ID already exists.');
+            throw new Exception\RuntimeException('Object with ID already exists.');
         }
 
         $this->scheduledInsertions[$oid]          = $object;
@@ -201,7 +201,7 @@ class UnitOfWork
     {
         $oid = spl_object_hash($object);
         if (! isset($this->identifiers[$oid])) {
-            throw new \RuntimeException(
+            throw new Exception\RuntimeException(
                 'Object scheduled for deletion is not managed. Only managed objects can be deleted.'
             );
         }
@@ -243,7 +243,7 @@ class UnitOfWork
             $id    = $this->idConverter->serialize($class, $id);
 
             if (! $id) {
-                throw new \RuntimeException('Trying to persist entity that has no id.');
+                throw new Exception\RuntimeException('Trying to persist entity that has no id.');
             }
 
             $data              = $this->getObjectSnapshot($class, $object);

--- a/tests/Doctrine/Tests/KeyValueStore/Functional/Storage/AzureSdkTableTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Functional/Storage/AzureSdkTableTest.php
@@ -68,7 +68,7 @@ class AzureSdkTableTest extends KeyValueStoreTestCase
 
         $storage->delete('test', $key);
 
-        $this->setExpectedException("Doctrine\KeyValueStore\NotFoundException");
+        $this->setExpectedException("Doctrine\KeyValueStore\Exception\NotFoundException");
         $storage->find('test', $key);
     }
 

--- a/tests/Doctrine/Tests/KeyValueStore/Functional/Storage/CassandraTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Functional/Storage/CassandraTest.php
@@ -110,7 +110,7 @@ class CassandraTest extends \PHPUnit_Framework_TestCase
         $this->storage->insert('books', ['id' => 4], $data);
         $this->storage->delete('books', ['id' => 4]);
 
-        $this->setExpectedException('Doctrine\KeyValueStore\NotFoundException');
+        $this->setExpectedException('Doctrine\KeyValueStore\Exception\NotFoundException');
 
         $this->storage->find('books', ['id' => 4]);
     }

--- a/tests/Doctrine/Tests/KeyValueStore/Functional/Storage/WindowsAzureTableTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Functional/Storage/WindowsAzureTableTest.php
@@ -75,7 +75,7 @@ class WindowsAzureTableTest extends KeyValueStoreTestCase
 
         $storage->delete('test', $key);
 
-        $this->setExpectedException("Doctrine\KeyValueStore\NotFoundException");
+        $this->setExpectedException("Doctrine\KeyValueStore\Exception\NotFoundException");
         $storage->find('test', $key);
     }
 

--- a/tests/Doctrine/Tests/KeyValueStore/Storage/RiakStorageTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Storage/RiakStorageTest.php
@@ -210,7 +210,7 @@ class RiakStorageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\KeyValueStore\NotFoundException
+     * @expectedException Doctrine\KeyValueStore\Exception\NotFoundException
      */
     public function testFindWithNotExistKey()
     {


### PR DESCRIPTION
With this structure every exception thrown by the key value store is marked with a specific interface.

Use case:
```php
try {
    // extract values from a DBAL storage
} catch (\Doctrine\KeyValueStore\Exception\NotFoundException $e) {
    // data not found
} catch (\Doctrine\KeyValueStore\Storage\Exception\Exception $e) {
    // generic storage-level exception
} catch (\Doctrine\KeyValueStore\Exception\RuntimeException $e) {
    // EntityManager or UnitOfWork runtime exception (extends \RuntimeException)
} catch (\Doctrine\KeyValueStore\Exception\Exception $e) {
    // EntityManager or UnitOfWork exception (extends \Exception)
} catch (\Doctrine\KeyValueStore\Exception $e) {
    // generic key value store exception
} catch (\Exception $e) {
    // generic exception
}
```

This is a RFC with the basic structure only, later I'll add message methods (following [this article](http://rosstuck.com/formatting-exception-messages/)) and tests.