### PR TITLE
Update DynamoDbStorage::find

### DIFF
--- a/lib/Doctrine/KeyValueStore/EntityManager.php
+++ b/lib/Doctrine/KeyValueStore/EntityManager.php
@@ -21,6 +21,7 @@
 namespace Doctrine\KeyValueStore;
 
 use Doctrine\KeyValueStore\Mapping\ClassMetadataFactory;
+use Doctrine\KeyValueStore\Query\QueryBuilder;
 use Doctrine\KeyValueStore\Query\RangeQuery;
 use Doctrine\KeyValueStore\Storage\Storage;
 
@@ -84,6 +85,20 @@ class EntityManager
     public function createRangeQuery($className, $partitionKey)
     {
         return new RangeQuery($this, $className, $partitionKey);
+    }
+
+    /**
+     * Create a query builder isntance for storage engines that support query builders
+     *
+     * Some vendors don't support queries at all.
+     *
+     * @param string $className
+     *
+     * @return \Doctrine\KeyValueStore\Query\QueryBuilder
+     */
+    public function createQueryBuilder($className)
+    {
+        return new QueryBuilder($this, $className);
     }
 
     /**

--- a/lib/Doctrine/KeyValueStore/Mapping/Annotations/Embeddable.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/Annotations/Embeddable.php
@@ -23,16 +23,11 @@ namespace Doctrine\KeyValueStore\Mapping\Annotations;
 /**
  * @Annotation
  * @Target("CLASS")
+ * Usage:
+ *     /**
+ *      * @KeyValue\Embeddable
+ *     class Test
  */
-final class Entity
+final class Embeddable
 {
-    /**
-     * @var string
-     */
-    public $storageName;
-
-    /**
-     * @var string
-     */
-    public $prefix;
 }

--- a/lib/Doctrine/KeyValueStore/Mapping/Annotations/Embedded.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/Annotations/Embedded.php
@@ -22,17 +22,15 @@ namespace Doctrine\KeyValueStore\Mapping\Annotations;
 
 /**
  * @Annotation
- * @Target("CLASS")
+ * @Target("PROPERTY")
+ * Usage:
+ *     @KeyValue\Embedded(target="Document\Test") 
+ *     private $test;
  */
-final class Entity
+final class Embedded
 {
     /**
      * @var string
      */
-    public $storageName;
-
-    /**
-     * @var string
-     */
-    public $prefix;
+    public $target;
 }

--- a/lib/Doctrine/KeyValueStore/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/ClassMetadata.php
@@ -160,7 +160,8 @@ class ClassMetadata implements BaseClassMetadata
      */
     public function hasAssociation($fieldName)
     {
-        return false;
+        return isset($this->fields[$fieldName])
+            && !empty($this->fields[$fieldName]['embedded']);
     }
 
     /**
@@ -243,6 +244,7 @@ class ClassMetadata implements BaseClassMetadata
      */
     public function getAssociationTargetClass($assocName)
     {
+        return $this->fields[$assocName]['embedded'];
     }
 
     /**

--- a/lib/Doctrine/KeyValueStore/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/KeyValueStore/Mapping/ClassMetadataFactory.php
@@ -63,7 +63,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $class->storageName = end($parts);
         }
 
-        if (! $class->identifier) {
+        if (! $class->identifier && ! $class->embeddable) {
             throw new \InvalidArgumentException('Class ' . $class->name . ' has no identifier.');
         }
     }

--- a/lib/Doctrine/KeyValueStore/Query/Expr.php
+++ b/lib/Doctrine/KeyValueStore/Query/Expr.php
@@ -1,0 +1,281 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore\Query;
+
+/**
+ * This class is used to generate query expressions via a set of PHP static functions.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author  Jonathan Wage <jonwage@gmail.com>
+ * @author  Roman Borschel <roman@code-factory.org>
+ * @author  Benjamin Eberlei <kontakt@beberlei.de>
+ * @todo Rename: ExpressionBuilder
+ */
+class Expr
+{
+    /**
+     * Creates a conjunction of the given boolean expressions.
+     *
+     * Example:
+     *
+     *     [php]
+     *     // (u.type = ?1) AND (u.role = ?2)
+     *     $expr->andX($expr->eq('u.type', ':1'), $expr->eq('u.role', ':2'));
+     *
+     * @param \Doctrine\KeyValueStore\Query\Expr\Comparison |
+     *        \Doctrine\KeyValueStore\Query\Expr\Func |
+     *        \Doctrine\KeyValueStore\Query\Expr\Orx
+     *        $x Optional clause. Defaults to null, but requires at least one defined when converting to string.
+     *
+     * @return Expr\Andx
+     */
+    public function andX($x = null)
+    {
+        return new Expr\Andx(func_get_args());
+    }
+
+    /**
+     * Creates a disjunction of the given boolean expressions.
+     *
+     * Example:
+     *
+     *     [php]
+     *     // (u.type = ?1) OR (u.role = ?2)
+     *     $q->where($q->expr()->orX('u.type = ?1', 'u.role = ?2'));
+     *
+     * @param mixed $x Optional clause. Defaults to null, but requires
+     *                 at least one defined when converting to string.
+     *
+     * @return Expr\Orx
+     */
+    public function orX($x = null)
+    {
+        return new Expr\Orx(func_get_args());
+    }
+
+    /**
+     * Creates an equality comparison expression with the given arguments.
+     *
+     * First argument is considered the left expression and the second is the right expression.
+     * When converted to string, it will generated a <left expr> = <right expr>. Example:
+     *
+     *     [php]
+     *     // u.id = ?1
+     *     $expr->eq('u.id', '?1');
+     *
+     * @param mixed $x Left expression.
+     * @param mixed $y Right expression.
+     *
+     * @return Expr\Comparison
+     */
+    public function eq($x, $y)
+    {
+        return new Expr\Comparison($x, Expr\Comparison::EQ, $y);
+    }
+
+    /**
+     * Creates an instance of Expr\Comparison, with the given arguments.
+     * First argument is considered the left expression and the second is the right expression.
+     * When converted to string, it will generated a <left expr> <> <right expr>. Example:
+     *
+     *     [php]
+     *     // u.id <> ?1
+     *     $q->where($q->expr()->neq('u.id', '?1'));
+     *
+     * @param mixed $x Left expression.
+     * @param mixed $y Right expression.
+     *
+     * @return Expr\Comparison
+     */
+    public function neq($x, $y)
+    {
+        return new Expr\Comparison($x, Expr\Comparison::NEQ, $y);
+    }
+
+    /**
+     * Creates an instance of Expr\Comparison, with the given arguments.
+     * First argument is considered the left expression and the second is the right expression.
+     * When converted to string, it will generated a <left expr> < <right expr>. Example:
+     *
+     *     [php]
+     *     // u.id < ?1
+     *     $q->where($q->expr()->lt('u.id', '?1'));
+     *
+     * @param mixed $x Left expression.
+     * @param mixed $y Right expression.
+     *
+     * @return Expr\Comparison
+     */
+    public function lt($x, $y)
+    {
+        return new Expr\Comparison($x, Expr\Comparison::LT, $y);
+    }
+
+    /**
+     * Creates an instance of Expr\Comparison, with the given arguments.
+     * First argument is considered the left expression and the second is the right expression.
+     * When converted to string, it will generated a <left expr> <= <right expr>. Example:
+     *
+     *     [php]
+     *     // u.id <= ?1
+     *     $q->where($q->expr()->lte('u.id', '?1'));
+     *
+     * @param mixed $x Left expression.
+     * @param mixed $y Right expression.
+     *
+     * @return Expr\Comparison
+     */
+    public function lte($x, $y)
+    {
+        return new Expr\Comparison($x, Expr\Comparison::LTE, $y);
+    }
+
+    /**
+     * Creates an instance of Expr\Comparison, with the given arguments.
+     * First argument is considered the left expression and the second is the right expression.
+     * When converted to string, it will generated a <left expr> > <right expr>. Example:
+     *
+     *     [php]
+     *     // u.id > ?1
+     *     $q->where($q->expr()->gt('u.id', '?1'));
+     *
+     * @param mixed $x Left expression.
+     * @param mixed $y Right expression.
+     *
+     * @return Expr\Comparison
+     */
+    public function gt($x, $y)
+    {
+        return new Expr\Comparison($x, Expr\Comparison::GT, $y);
+    }
+
+    /**
+     * Creates an instance of Expr\Comparison, with the given arguments.
+     * First argument is considered the left expression and the second is the right expression.
+     * When converted to string, it will generated a <left expr> >= <right expr>. Example:
+     *
+     *     [php]
+     *     // u.id >= ?1
+     *     $q->where($q->expr()->gte('u.id', '?1'));
+     *
+     * @param mixed $x Left expression.
+     * @param mixed $y Right expression.
+     *
+     * @return Expr\Comparison
+     */
+    public function gte($x, $y)
+    {
+        return new Expr\Comparison($x, Expr\Comparison::GTE, $y);
+    }
+
+    /**
+     * Creates an IN() expression with the given arguments.
+     *
+     * @param string $x Field in string format to be restricted by IN() function.
+     * @param mixed  $y Argument to be used in IN() function.
+     *
+     * @return Expr\Func
+     */
+    public function in($x, $y)
+    {
+        if (is_array($y)) {
+            foreach ($y as &$literal) {
+                if ( ! ($literal instanceof Expr\Literal)) {
+                    $literal = $this->_quoteLiteral($literal);
+                }
+            }
+        }
+        return new Expr\Func($x . ' IN', (array) $y);
+    }
+
+    /**
+     * Creates a NOT IN() expression with the given arguments.
+     *
+     * @param string $x Field in string format to be restricted by NOT IN() function.
+     * @param mixed $y Argument to be used in NOT IN() function.
+     *
+     * @return Expr\Func
+     */
+    public function notIn($x, $y)
+    {
+        if (is_array($y)) {
+            foreach ($y as &$literal) {
+                if ( ! ($literal instanceof Expr\Literal)) {
+                    $literal = $this->_quoteLiteral($literal);
+                }
+            }
+        }
+        return new Expr\Func($x . ' NOT IN', (array) $y);
+    }
+
+    /**
+     * Creates a CONTAINS() comparison expression with the given arguments.
+     *
+     * @param string $x Field in string format to be inspected by CONTAINS() comparison.
+     * @param mixed  $y Argument to be used in CONTAINS() comparison.
+     *
+     * @return Expr\Comparison
+     */
+    public function contains($x, $y)
+    {
+        return new Expr\Func('contains', [$x, $y]);
+    }
+
+    /**
+     * Creates a NOT CONTAINS() comparison expression with the given arguments.
+     *
+     * @param string $x Field in string format to be inspected by LIKE() comparison.
+     * @param mixed  $y Argument to be used in LIKE() comparison.
+     *
+     * @return Expr\Comparison
+     */
+    public function notLike($x, $y)
+    {
+        return new Expr\Comparison($x, 'NOT CONTAINS', $y);
+    }
+
+    /**
+     * Creates a SIZE() function expression with the given argument.
+     *
+     * @param mixed $x Argument to be used as argument of SIZE() function.
+     *
+     * @return Expr\Func A SIZE function expression.
+     */
+    public function size($x)
+    {
+        return new Expr\Func('SIZE', array($x));
+    }
+
+    /**
+     * Creates an instance of BETWEEN() function, with the given argument.
+     *
+     * @param mixed   $val Valued to be inspected by range values.
+     * @param integer $x   Starting range value to be used in BETWEEN() function.
+     * @param integer $y   End point value to be used in BETWEEN() function.
+     *
+     * @return Expr\Func A BETWEEN expression.
+     */
+    public function between($val, $x, $y)
+    {
+        return $val . ' BETWEEN ' . $x . ' AND ' . $y;
+    }
+}

--- a/lib/Doctrine/KeyValueStore/Query/Expr/Andx.php
+++ b/lib/Doctrine/KeyValueStore/Query/Expr/Andx.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -18,21 +17,47 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore\Mapping\Annotations;
+namespace Doctrine\KeyValueStore\Query\Expr;
 
 /**
- * @Annotation
- * @Target("CLASS")
+ * Expression class for building DQL and parts.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author  Jonathan Wage <jonwage@gmail.com>
+ * @author  Roman Borschel <roman@code-factory.org>
  */
-final class Entity
+class Andx extends Composite
 {
     /**
      * @var string
      */
-    public $storageName;
+    protected $separator = ' AND ';
 
     /**
-     * @var string
+     * @var array
      */
-    public $prefix;
+    protected $allowedClasses = array(
+        'Doctrine\KeyValueStore\Query\Expr\Comparison',
+        'Doctrine\KeyValueStore\Query\Expr\Func',
+        'Doctrine\KeyValueStore\Query\Expr\Orx',
+        'Doctrine\KeyValueStore\Query\Expr\Andx',
+    );
+
+    /**
+     * @return array
+     */
+    public function getParts()
+    {
+        return $this->parts;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSeparator()
+    {
+        return $this->separator;
+    }
 }

--- a/lib/Doctrine/KeyValueStore/Query/Expr/Base.php
+++ b/lib/Doctrine/KeyValueStore/Query/Expr/Base.php
@@ -1,0 +1,124 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore\Query\Expr;
+
+/**
+ * Abstract base Expr class for building DQL parts.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author  Jonathan Wage <jonwage@gmail.com>
+ * @author  Roman Borschel <roman@code-factory.org>
+ */
+abstract class Base
+{
+    /**
+     * @var string
+     */
+    protected $preSeparator = '(';
+
+    /**
+     * @var string
+     */
+    protected $separator = ', ';
+
+    /**
+     * @var string
+     */
+    protected $postSeparator = ')';
+
+    /**
+     * @var array
+     */
+    protected $allowedClasses = array();
+
+    /**
+     * @var array
+     */
+    protected $parts = array();
+
+    /**
+     * @param array $args
+     */
+    public function __construct($args = array())
+    {
+        $this->addMultiple($args);
+    }
+
+    /**
+     * @param array $args
+     *
+     * @return Base
+     */
+    public function addMultiple($args = array())
+    {
+        foreach ((array) $args as $arg) {
+            $this->add($arg);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $arg
+     *
+     * @return Base
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function add($arg)
+    {
+        if ( $arg !== null && (!$arg instanceof self || $arg->count() > 0) ) {
+            // If we decide to keep Expr\Base instances, we can use this check
+            if ( ! is_string($arg)) {
+                $class = get_class($arg);
+
+                if ( ! in_array($class, $this->allowedClasses)) {
+                    throw new \InvalidArgumentException("Expression of type '$class' not allowed in this context.");
+                }
+            }
+
+            $this->parts[] = $arg;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return integer
+     */
+    public function count()
+    {
+        return count($this->parts);
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        if ($this->count() == 1) {
+            return (string) $this->parts[0];
+        }
+
+        return $this->preSeparator . implode($this->separator, $this->parts) . $this->postSeparator;
+    }
+}

--- a/lib/Doctrine/KeyValueStore/Query/Expr/Comparison.php
+++ b/lib/Doctrine/KeyValueStore/Query/Expr/Comparison.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore\Query\Expr;
+
+/**
+ * Expression class for DQL comparison expressions.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author  Jonathan Wage <jonwage@gmail.com>
+ * @author  Roman Borschel <roman@code-factory.org>
+ */
+class Comparison
+{
+    const EQ  = '=';
+    const NEQ = '<>';
+    const LT  = '<';
+    const LTE = '<=';
+    const GT  = '>';
+    const GTE = '>=';
+
+    /**
+     * @var mixed
+     */
+    protected $leftExpr;
+
+    /**
+     * @var string
+     */
+    protected $operator;
+
+    /**
+     * @var mixed
+     */
+    protected $rightExpr;
+
+    /**
+     * Creates a comparison expression with the given arguments.
+     * 
+     * @param mixed  $leftExpr
+     * @param string $operator
+     * @param mixed  $rightExpr
+     */
+    public function __construct($leftExpr, $operator, $rightExpr)
+    {
+        $this->leftExpr  = $leftExpr;
+        $this->operator  = $operator;
+        $this->rightExpr = $rightExpr;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLeftExpr()
+    {
+        return $this->leftExpr;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOperator()
+    {
+        return $this->operator;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getRightExpr()
+    {
+        return $this->rightExpr;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->leftExpr . ' ' . $this->operator . ' ' . $this->rightExpr;
+    }
+}

--- a/lib/Doctrine/KeyValueStore/Query/Expr/Composite.php
+++ b/lib/Doctrine/KeyValueStore/Query/Expr/Composite.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore\Query\Expr;
+
+/**
+ * Expression class for building DQL and parts.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author  Jonathan Wage <jonwage@gmail.com>
+ * @author  Roman Borschel <roman@code-factory.org>
+ */
+class Composite extends Base
+{
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        if ($this->count() === 1) {
+            return (string) $this->parts[0];
+        }
+
+        $components = array();
+
+        foreach ($this->parts as $part) {
+            $components[] = $this->processQueryPart($part);
+        }
+
+        return implode($this->separator, $components);
+    }
+
+    /**
+     * @param string $part
+     *
+     * @return string
+     */
+    private function processQueryPart($part)
+    {
+        $queryPart = (string) $part;
+
+        if (is_object($part) && $part instanceof self && $part->count() > 1) {
+            return $this->preSeparator . $queryPart . $this->postSeparator;
+        }
+
+        // Fixes DDC-1237: User may have added a where item containing nested expression (with "OR" or "AND")
+        if (stripos($queryPart, ' OR ') !== false || stripos($queryPart, ' AND ') !== false) {
+            return $this->preSeparator . $queryPart . $this->postSeparator;
+        }
+
+        return $queryPart;
+    }
+}

--- a/lib/Doctrine/KeyValueStore/Query/Expr/Func.php
+++ b/lib/Doctrine/KeyValueStore/Query/Expr/Func.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore\Query\Expr;
+
+/**
+ * Expression class for generating DQL functions.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author  Jonathan Wage <jonwage@gmail.com>
+ * @author  Roman Borschel <roman@code-factory.org>
+ */
+class Func
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var array
+     */
+    protected $arguments;
+
+    /**
+     * Creates a function, with the given argument.
+     *
+     * @param string $name
+     * @param array  $arguments
+     */
+    public function __construct($name, $arguments)
+    {
+        $this->name         = $name;
+        $this->arguments    = (array) $arguments;
+    }
+
+    /**
+     * @return string 
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->name . '(' . implode(', ', $this->arguments) . ')';
+    }
+}

--- a/lib/Doctrine/KeyValueStore/Query/Expr/Orx.php
+++ b/lib/Doctrine/KeyValueStore/Query/Expr/Orx.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -18,21 +17,47 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore\Mapping\Annotations;
+namespace Doctrine\KeyValueStore\Query\Expr;
 
 /**
- * @Annotation
- * @Target("CLASS")
+ * Expression class for building DQL OR clauses.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author  Jonathan Wage <jonwage@gmail.com>
+ * @author  Roman Borschel <roman@code-factory.org>
  */
-final class Entity
+class Orx extends Composite
 {
     /**
      * @var string
      */
-    public $storageName;
+    protected $separator = ' OR ';
 
     /**
-     * @var string
+     * @var array
      */
-    public $prefix;
+    protected $allowedClasses = array(
+        'Doctrine\KeyValueStore\Query\Expr\Comparison',
+        'Doctrine\KeyValueStore\Query\Expr\Func',
+        'Doctrine\KeyValueStore\Query\Expr\Andx',
+        'Doctrine\KeyValueStore\Query\Expr\Orx',
+    );
+
+    /**
+     * @return array
+     */
+    public function getParts()
+    {
+        return $this->parts;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSeparator()
+    {
+        return $this->separator;
+    }
 }

--- a/lib/Doctrine/KeyValueStore/Query/Parameter.php
+++ b/lib/Doctrine/KeyValueStore/Query/Parameter.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore\Query;
+
+/**
+ * Defines a Query Parameter.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.3
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ */
+class Parameter
+{
+    /**
+     * The parameter name.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The parameter value.
+     *
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * The parameter type.
+     *
+     * @var mixed
+     */
+    private $type;
+
+    /**
+     * Constructor.
+     *
+     * @param string $name  Parameter name
+     * @param mixed  $value Parameter value
+     */
+    public function __construct($name, $value)
+    {
+        $this->name = trim($name, ':');
+
+        $this->setValue($value);
+    }
+
+    /**
+     * Retrieves the Parameter name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Retrieves the Parameter value.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Defines the Parameter value.
+     *
+     * @param mixed $value Parameter value.
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/lib/Doctrine/KeyValueStore/Query/Query.php
+++ b/lib/Doctrine/KeyValueStore/Query/Query.php
@@ -18,21 +18,17 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore\Mapping\Annotations;
+namespace Doctrine\KeyValueStore\Query;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\KeyValueStore\EntityManager;
 
 /**
- * @Annotation
- * @Target("CLASS")
+ * Query Object.  
  */
-final class Entity
+class Query
 {
-    /**
-     * @var string
-     */
-    public $storageName;
-
-    /**
-     * @var string
-     */
-    public $prefix;
+    public function getResult()
+    {
+    }
 }

--- a/lib/Doctrine/KeyValueStore/Query/QueryBuilder.php
+++ b/lib/Doctrine/KeyValueStore/Query/QueryBuilder.php
@@ -1,0 +1,322 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\KeyValueStore\Query;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\KeyValueStore\EntityManager;
+
+/**
+ * Range Query Object. It always requires a partition/hash key and
+ * optionally conditions on the range key.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ */
+class QueryBuilder
+{
+    /**
+     * @param string
+     */
+    protected $className;
+
+    /**
+     * @var array
+     */
+    protected $condition = null;
+
+    /**
+     * @var EntityManager
+     */
+    protected $em;
+
+    /**
+     * @var Expr
+     **/
+    protected $expr;
+
+    /**
+     * The query parameters.
+     *
+     * @var \Doctrine\Common\Collections\ArrayCollection
+     */
+    private $parameters;
+
+    /**
+     * @var callable
+     **/
+    private $hydrator;
+
+    public function __construct(EntityManager $em, $className)
+    {
+        $this->em           = $em;
+        $this->className    = $className;
+        $this->parameters   = new ArrayCollection();
+    }
+
+    /**
+     * Get className.
+     *
+     * @return className.
+     */
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    /**
+     * Get condition
+     *
+     * @return array
+     */
+    public function getCondition()
+    {
+        return $this->condition;
+    }
+
+    /**
+     * Set the hydrator callable
+     *
+     * @param callable $hydrator
+     **/
+    public function setHydrator($hydrator)
+    {
+        $this->hydrator = $hydrator;
+        return $this;
+    }
+
+    /**
+     * Execute query and return a result iterator.
+     *
+     * @return ResultIterator
+     */
+    public function getResult()
+    {
+        $storage = $this->em->unwrap();
+
+        if (! $storage instanceof QueryBuilderStorage) {
+            throw new \RuntimeException(
+                'The storage backend ' . $storage->getName() . ' does not support query builder queries.'
+            );
+        }
+
+        $uow      = $this->em->getUnitOfWork();
+        $class    = $this->em->getClassMetadata($this->className);
+        $hydrator = $this->hydrator;
+
+        $rowHydration = function ($row) use ($uow, $class, $hydrator) {
+            $key = [];
+
+            foreach ($class->identifier as $id) {
+                //TODO check if row value is not set
+                $key = $row[$id];
+            }
+
+            $hydratedObject = $uow->createEntity($class, $key, $row);
+
+            if ($hydrator) {
+                $hydratedObject = call_user_func($hydrator, $hydratedObject);
+            }
+
+            return $hydratedObject;
+        };
+
+        return $storage->executeQueryBuilder($this, $class->storageName, $class->identifier, $rowHydration);
+    }
+
+    /**
+     * Execute query and return a result iterator.
+     *
+     * @return ResultIterator
+     */
+    public function getSingleResult()
+    {
+        $results = $this->getResult();
+        return count($results) > 0 ? $results[0] : $results;
+    }
+
+
+    /**
+     * Specifies one or more restrictions to the query result.
+     * Replaces any previously specified restrictions, if any.
+     *
+     * <code>
+     *     $qb = $em->createQueryBuilder()
+     *         ->select('u')
+     *         ->from('User', 'u')
+     *         ->where('u.id = ?');
+     *
+     *     // You can optionally programatically build and/or expressions
+     *     $qb = $em->createQueryBuilder();
+     *
+     *     $or = $qb->expr()->orx();
+     *     $or->add($qb->expr()->eq('u.id', 1));
+     *     $or->add($qb->expr()->eq('u.id', 2));
+     *
+     *     $qb->update('User', 'u')
+     *         ->set('u.password', md5('password'))
+     *         ->where($or);
+     * </code>
+     *
+     * @param mixed $predicates The restriction predicates.
+     *
+     * @return QueryBuilder This QueryBuilder instance.
+     */
+    public function where($predicates)
+    {
+        if ( ! (func_num_args() == 1 && $predicates instanceof Expr\Composite)) {
+            $predicates = new Expr\Andx(func_get_args());
+        }
+
+        $this->condition = $predicates;
+        return $this;
+    }
+
+    /**
+     * Adds one or more restrictions to the query results, forming a logical
+     * conjunction with any previously specified restrictions.
+     *
+     * <code>
+     *     $qb = $em->createQueryBuilder()
+     *         ->select('u')
+     *         ->from('User', 'u')
+     *         ->where('u.username LIKE ?')
+     *         ->andWhere('u.is_active = 1');
+     * </code>
+     *
+     * @param mixed $where The query restrictions.
+     *
+     * @return QueryBuilder This QueryBuilder instance.
+     *
+     * @see where()
+     */
+    public function andWhere()
+    {
+        $args  = func_get_args();
+        $where = $this->condition;
+
+        if ($where instanceof Expr\Andx) {
+            $where->addMultiple($args);
+        } else {
+            array_unshift($args, $where);
+            $where = new Expr\Andx($args);
+        }
+
+        $this->condition = $where;
+        return $this;
+    }
+
+    /**
+     * Adds one or more restrictions to the query results, forming a logical
+     * disjunction with any previously specified restrictions.
+     *
+     * <code>
+     *     $qb = $em->createQueryBuilder()
+     *         ->select('u')
+     *         ->from('User', 'u')
+     *         ->where('u.id = 1')
+     *         ->orWhere('u.id = 2');
+     * </code>
+     *
+     * @param mixed $where The WHERE statement.
+     *
+     * @return QueryBuilder
+     *
+     * @see where()
+     */
+    public function orWhere()
+    {
+        $args  = func_get_args();
+        $where = $this->condition;
+
+        if ($where instanceof Expr\Orx) {
+            $where->addMultiple($args);
+        } else {
+            array_unshift($args, $where);
+            $where = new Expr\Orx($args);
+        }
+
+        $this->condition = $where;
+        return $this;
+    }
+
+    /**
+     *
+     * @return Query\Expr
+     */
+    public function expr()
+    {
+        if ($this->expr === null) {
+            $this->expr = new Expr;
+        }
+
+        return $this->expr;
+    }
+
+    /**
+     * Sets a query parameter for the query being constructed.
+     *
+     * <code>
+     *     $qb = $em->createQueryBuilder()
+     *         ->select('u')
+     *         ->from('User', 'u')
+     *         ->where('u.id = :user_id')
+     *         ->setParameter('user_id', 1);
+     * </code>
+     *
+     * @param string|integer $key   The parameter position or name.
+     * @param mixed          $value The parameter value.
+     * @param string|null    $type  PDO::PARAM_* or \Doctrine\DBAL\Types\Type::* constant
+     *
+     * @return QueryBuilder This QueryBuilder instance.
+     */
+    public function setParameter($key, $value, $type = null)
+    {
+        $filteredParameters = $this->parameters->filter(
+            function ($parameter) use ($key)
+            {
+                // Must not be identical because of string to integer conversion
+                return ($key == $parameter->getName());
+            }
+        );
+
+        if (count($filteredParameters)) {
+            $parameter = $filteredParameters->first();
+            $parameter->setValue($value, $type);
+
+            return $this;
+        }
+
+        $parameter = new Parameter($key, $value, $type);
+
+        $this->parameters->add($parameter);
+
+        return $this;
+    }
+
+    /**
+     * Gets all defined query parameters for the query being constructed.
+     *
+     * @return \Doctrine\Common\Collections\ArrayCollection The currently defined query parameters.
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/lib/Doctrine/KeyValueStore/Query/QueryBuilderStorage.php
+++ b/lib/Doctrine/KeyValueStore/Query/QueryBuilderStorage.php
@@ -18,21 +18,24 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\KeyValueStore\Mapping\Annotations;
+namespace Doctrine\KeyValueStore\Query;
 
 /**
- * @Annotation
- * @Target("CLASS")
+ * Interface used by storages that support filter-based queries 
+ *
+ * @author Derek Woods <derekrw@gmail.com>
  */
-final class Entity
+interface QueryBuilderStorage
 {
     /**
-     * @var string
+     * Execute the filter query and return a ResultIterator
+     *
+     * @param QueryBuilder $qb
+     * @param string     $storageName
+     * @param array      $key
+     * @param Closure    $hydrateRow
+     *
+     * @return ResultIterator
      */
-    public $storageName;
-
-    /**
-     * @var string
-     */
-    public $prefix;
+    public function executeQueryBuilder(QueryBuilder $qb, $storageName, $key, \Closure $hydrateRow = null);
 }

--- a/lib/Doctrine/KeyValueStore/Storage/DynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/DynamoDbStorage.php
@@ -280,11 +280,11 @@ class DynamoDbStorage implements Storage
           self::TABLE_KEY           => $this->prepareKey($storageName, $key),
         ]);
 
+        $item = $item->get(self::TABLE_ITEM_KEY);
+
         if (! $item) {
             throw NotFoundException::notFoundByKey($key);
         }
-
-        $item = $item->get(self::TABLE_ITEM_KEY);
 
         return $this->marshaler->unmarshalItem($item);
     }

--- a/lib/Doctrine/KeyValueStore/UnitOfWork.php
+++ b/lib/Doctrine/KeyValueStore/UnitOfWork.php
@@ -100,21 +100,46 @@ class UnitOfWork
 
     public function createEntity($class, $id, $data)
     {
-        if (isset($data['php_class'])) {
-            if ($data['php_class'] !== $class->name && ! is_subclass_of($data['php_class'], $class->name)) {
-                throw new \RuntimeException(
-                    "Row is of class '" . $data['php_class'] . "' which is not a subtype of expected " . $class->name
-                );
-            }
-            $class = $this->cmf->getMetadataFor($data['php_class']);
-        }
-        unset($data['php_class']);
-
         $object = $this->tryGetById($class->name, $id);
         if ($object) {
             return $object;
         }
 
+        $object = $class->newInstance();
+
+        $oid                      = spl_object_hash($object);
+        $this->originalData[$oid] = $data;
+        $data                     = $this->idConverter->unserialize($class, $data);
+
+        foreach ($data as $property => $value) {
+            if (isset($class->reflFields[$property])) {
+                if ($class->hasAssociation($property)) {
+                    $associationClass = $class->getAssociationTargetClass($property);
+                    $associationMeta = $this->cmf->getMetadataFor($associationClass);
+                    $class->reflFields[$property]->setValue(
+                        $object,
+                        $this->createEmbeddedEntity($associationMeta, $value)
+                    );
+                    continue;
+                }
+                $class->reflFields[$property]->setValue($object, $value);
+            } else {
+                $object->$property = $value;
+            }
+        }
+
+        if (is_array($id)) {
+            $id = current($id);
+        }
+        $idHash                                   = $this->idHandler->hash($id);
+        $this->identityMap[$class->name][$idHash] = $object;
+        $this->identifiers[$oid]                  = $id;
+
+        return $object;
+    }
+
+    public function createEmbeddedEntity($class, $data)
+    {
         $object = $class->newInstance();
 
         $oid                      = spl_object_hash($object);
@@ -129,12 +154,9 @@ class UnitOfWork
             }
         }
 
-        $idHash                                   = $this->idHandler->hash($id);
-        $this->identityMap[$class->name][$idHash] = $object;
-        $this->identifiers[$oid]                  = $id;
-
         return $object;
     }
+
 
     private function computeChangeSet($class, $object)
     {
@@ -158,9 +180,21 @@ class UnitOfWork
     {
         $data = [];
 
+        if (!$object) {
+            return $data;
+        }
+
         foreach ($class->reflFields as $fieldName => $reflProperty) {
             if (! isset($class->fields[$fieldName]['id'])) {
-                $data[$fieldName] = $reflProperty->getValue($object);
+                if ($class->hasAssociation($fieldName)) {
+                    $embeddedMeta = $this->cmf->getMetadataFor($class->getAssociationTargetClass($fieldName));
+                    $data[$fieldName] = $this->getObjectSnapshot($embeddedMeta, $reflProperty->getValue($object));
+                    continue;
+                }
+
+                if (is_object($object)) {
+                    $data[$fieldName] = $reflProperty->getValue($object);
+                }
             }
         }
 
@@ -222,7 +256,6 @@ class UnitOfWork
                 $changeSet = $this->computeChangeSet($metadata, $object);
 
                 if ($changeSet) {
-                    $changeSet['php_class'] = $metadata->name;
                     $this->storageDriver->update($metadata->storageName, $this->identifiers[$hash], $changeSet);
 
                     if ($this->storageDriver->supportsPartialUpdates()) {
@@ -247,7 +280,6 @@ class UnitOfWork
             }
 
             $data              = $this->getObjectSnapshot($class, $object);
-            $data['php_class'] = $class->name;
 
             $oid    = spl_object_hash($object);
             $idHash = $this->idHandler->hash($id);

--- a/tests/Doctrine/Tests/KeyValueStore/Storage/DynamoDbTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Storage/DynamoDbTest.php
@@ -310,11 +310,13 @@ class DynamoDbTest extends \PHPUnit_Framework_TestCase
     public function testTryingToFindAnItemThatDoesNotExist()
     {
         $client = $this->getDynamoDbMock(['getItem']);
+        $result = $this->getDynamoDbResultMock(['get']);
+        $result->expects($this->once())->method('get')->with('Item')->willReturn(null);
         $client->expects($this->once())->method('getItem')->with($this->equalTo([
             'TableName'      => 'MyTable',
             'ConsistentRead' => true,
             'Key'            => ['Id' => ['N' => '1000']],
-        ]))->willReturn(null);
+        ]))->willReturn($result);
 
         $storage = new DynamoDbStorage($client);
         $this->setExpectedException(


### PR DESCRIPTION
The code below returns an object of Aws\Result even when the table key does not exist in DynamoDB:
```
$item = $this->client->getItem([
    self::TABLE_NAME_KEY      => $storageName,
    self::CONSISTENT_READ_KEY => true,
    self::TABLE_KEY           => $this->prepareKey($storageName, $key),
]);
```
Causing this check to pass:
```
if (! $item) {
   throw NotFoundException::notFoundByKey($key);
}
```
Since the key does not exist a null value is set here:
`$item = $item->get(self::TABLE_ITEM_KEY);`
Then that null $item is passed to:
`$this->marshaler->unmarshalItem($item);`
Which causes a fatal error.

This fix checks $item after attempting to get it instead of before.