### PR TITLE
Fix DynamoDbStorage::find

### DIFF
--- a/lib/Doctrine/KeyValueStore/Storage/DynamoDbStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/DynamoDbStorage.php
@@ -280,7 +280,7 @@ class DynamoDbStorage implements Storage
           self::TABLE_KEY           => $this->prepareKey($storageName, $key),
         ]);
 
-        if (! $item) {
+        if (false === $item->hasKey(self::TABLE_ITEM_KEY)) {
             throw NotFoundException::notFoundByKey($key);
         }
 

--- a/tests/Doctrine/Tests/KeyValueStore/Storage/DynamoDbTest.php
+++ b/tests/Doctrine/Tests/KeyValueStore/Storage/DynamoDbTest.php
@@ -309,12 +309,15 @@ class DynamoDbTest extends \PHPUnit_Framework_TestCase
 
     public function testTryingToFindAnItemThatDoesNotExist()
     {
+        $result = $this->getDynamoDbResultMock(['hasKey', 'get']);
+        $result->expects($this->once())->method('hasKey')->with('Item')->willReturn(false);
+
         $client = $this->getDynamoDbMock(['getItem']);
         $client->expects($this->once())->method('getItem')->with($this->equalTo([
             'TableName'      => 'MyTable',
             'ConsistentRead' => true,
             'Key'            => ['Id' => ['N' => '1000']],
-        ]))->willReturn(null);
+        ]))->willReturn($result);
 
         $storage = new DynamoDbStorage($client);
         $this->setExpectedException(
@@ -326,7 +329,8 @@ class DynamoDbTest extends \PHPUnit_Framework_TestCase
 
     public function testFindAnItemThatExists()
     {
-        $result = $this->getDynamoDbResultMock(['get']);
+        $result = $this->getDynamoDbResultMock(['hasKey', 'get']);
+        $result->expects($this->once())->method('hasKey')->with('Item')->willReturn(true);
         $result->expects($this->once())->method('get')->with('Item')->willReturn([
             'hello' => ['S' => 'world'],
         ]);


### PR DESCRIPTION
Duplicate of (abandoned) https://github.com/doctrine/KeyValueStore/pull/84.

As per [method signature](https://github.com/aws/aws-sdk-php/blob/3.36.13/src/DynamoDb/DynamoDbClient.php#L26):

```php
/**
 * @method \Aws\Result getItem(array $args = [])
 */
```