### PR TITLE
RiakStorage upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,23 @@ php:
   - 7.2
   - 7.3
 
+addons:
+    apt:
+        sources:
+            -
+                key_url: 'https://packagecloud.io/gpg.key'
+                sourceline: 'deb https://packagecloud.io/basho/riak/ubuntu/ trusty main'
+            -
+                key_url: 'https://packagecloud.io/gpg.key'
+                sourceline: 'deb-src https://packagecloud.io/basho/riak/ubuntu/ trusty main'
+        update: true
+
+cache:
+    apt: true
+
 before_install:
+  - sudo apt-get install -y --allow-unauthenticated riak
+  - sudo service riak start
   - pecl install --force mongodb
   - if [[ ${TRAVIS_PHP_VERSION:0:1} != "7" ]]; then sh ./tests/travis.sh; fi
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,13 @@
         "doctrine/couchdb": "^1.0.0-beta4",
         "phpunit/phpunit": "^4.8|^5.0",
         "aws/aws-sdk-php": "^3.8",
-        "riak/riak-client": "dev-master",
+        "php-riak/riak-client": "^1.0@alpha",
         "mongodb/mongodb": "^1.4"
     },
     "suggest": {
         "aws/aws-sdk-php": "to use the DynamoDB storage",
         "doctrine/couchdb": "to use the CouchDB storage",
-        "ext-couchbase": "to use the Couchbase storage",
-        "riak/riak-client": "to use the Riak storage"
+        "ext-couchbase": "to use the Couchbase storage"
     },
     "description": "Simple Key-Value Store Abstraction Layer that maps to PHP objects, allowing for many backends.",
     "license": "MIT",

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -242,15 +242,17 @@ instance.
 Riak
 ----
 
-Riak support is provided through the library `riak/riak-client <https://github.com/nacmartin/riak-client>`_ :
+Riak support is provided through the library `php-riak/riak-client <https://github.com/php-riak/riak-client>`_ :
 
 .. code-block:: php
 
     <?php
 
     use Doctrine\KeyValueStore\Storage\RiakStorage;
-    use Riak\Client;
+    use Riak\Client\RiakClientBuilder;
 
-    $conn = new Riak(/* connection parameters */);
+    $conn = (new RiakClientBuilder())
+        ->withNodeUri(/* connection DNS */)
+        ->build();
 
     $storage = new RiakStorage($conn);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,5 +16,6 @@
         <var name="DOCTRINE_KEYVALUE_AZURE_AUTHSCHEMA" value="sharedlite" />
         <var name="DOCTRINE_KEYVALUE_AZURE_NAME" value="" />
         <var name="DOCTRINE_KEYVALUE_AZURE_KEY" value="" />
+        <env name="RIAK_DNS" value="" />
     </php>
 </phpunit>


### PR DESCRIPTION
Fixes https://github.com/doctrine/KeyValueStore/issues/91

Things done:

1. drop PHP 5.5 support: riak package, Travis, PHP itself, etc... nobody is supporting it anymore
2. replaced [riak/riak-client:dev-master](https://packagist.org/packages/riak/riak-client#dev-master) with [php-riak/riak-client:v1.0.0-alpha7](https://packagist.org/packages/php-riak/riak-client#v1.0.0-alpha7): the first doesn't support PHP 7.0+ and isn't maintained
3. changed unit test for Riak with an integration test