### PR TITLE
MongoDbStorage upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ php:
   - 7.3
 
 before_install:
+  - pecl install --force mongodb
   - if [[ ${TRAVIS_PHP_VERSION:0:1} != "7" ]]; then sh ./tests/travis.sh; fi
   - composer self-update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ services:
   - mongodb
   - redis-server
 
-matrix:
-    include:
-        -
-            dist: precise
-            php: 5.5
-
 php:
   - 5.6
   - 7.0

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,7 @@
+# Upgrade to 0.3
+
+## BC Break: Fixed MongoDB storage usage
+
+Before v0.3 the storage name associated to a class wasn't used when the storage is `MongoDbStorage`.
+In order to be consistent with other storage drivers, the `storageName` is now used for the collection name when storing and data.
+To get the same behavior as in older versions, pass the collection name given in the constructor arguments as storage name.

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "doctrine/couchdb": "^1.0.0-beta4",
         "phpunit/phpunit": "^4.8|^5.0",
         "aws/aws-sdk-php": "^3.8",
-        "riak/riak-client": "dev-master"
+        "riak/riak-client": "dev-master",
+        "mongodb/mongodb": "^1.4"
     },
     "suggest": {
         "aws/aws-sdk-php": "to use the DynamoDB storage",

--- a/docs/reference/basic-usage.rst
+++ b/docs/reference/basic-usage.rst
@@ -8,7 +8,7 @@ This guide covers getting started with the Doctrine Key Value Store.
 
 To use the KeyValueStore you actually need:
 
-- PHP 5.5 or above
+- PHP 5.6 or above
 - Composer Package Manager (`Install Composer
   <http://getcomposer.org/doc/00-intro.md>`_)
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -224,23 +224,20 @@ See the `AWS docs <http://docs.aws.amazon.com/amazondynamodb/latest/developergui
 MongoDB
 -------
 
-Mongo support is provided using a `Mongo <http://php.net/manual/en/class.mongo.php>`_
-instance, the collection name and the database name.
-
-Both the options ``collection`` and ``database`` are required.
+MongoDB is based on `mongodb/mongodb <https://github.com/mongodb/mongo-php-library>`_:
+MongoDB support is provided using a `Database <https://docs.mongodb.com/php-library/current/reference/class/MongoDBDatabase/>`_
+instance.
 
 .. code-block:: php
 
     <?php
 
+    use MongoDB\Client;
     use Doctrine\KeyValueStore\Storage\MongoDbStorage;
 
-    $conn = new \Mongo(/* connection parameters and options */);
+    $client = new Client(/* connection parameters and options */);
 
-    $storage = new MongoDbStorage($conn, array(
-        'collection' => 'your_collection',
-        'database'   => 'your_database',
-    ));
+    $storage = new MongoDbStorage($client->your_database);
 
 Riak
 ----

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -7,7 +7,5 @@ sudo apt-get install -y libuv-dev libssl-dev
 cd /tmp && git clone https://github.com/datastax/php-driver.git && cd php-driver && git submodule update --init
 cd ext && ./install.sh && cd "$TRAVIS_BUILD_DIR"
 echo "extension=cassandra.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
-# PHP extensions
-yes | pecl install mongo
 # PECL extensions
 echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
Fixes https://github.com/doctrine/KeyValueStore/issues/93

Things done:

1. drop PHP 5.5 support: mongodb package, Travis, PHP itself, etc... nobody is supporting it anymore
2. replaced deprecated `ext-mongo` with [`mongodb/mongodb:^1.4`](https://packagist.org/packages/mongodb/mongodb#1.4.0)
3. changed unit test for MongoDB with an integration test