### PR TITLE
Fix fetch from array storage

### DIFF
--- a/lib/Doctrine/KeyValueStore/Storage/ArrayStorage.php
+++ b/lib/Doctrine/KeyValueStore/Storage/ArrayStorage.php
@@ -121,7 +121,7 @@ class ArrayStorage implements Storage
             throw new NotFoundException();
         }
 
-        unset($this->data[$storageName][serialize($key)]);
+        return $this->data[$storageName][serialize($key)];
     }
 
     /**


### PR DESCRIPTION
Implementation of `\Doctrine\KeyValueStore\Storage\ArrayStorage::find()` has been copy-pasted from `delete()` including the unset logic instead of replacing it with return.